### PR TITLE
Integrated add user. 

### DIFF
--- a/app/controller/apicontroller.js
+++ b/app/controller/apicontroller.js
@@ -53,12 +53,12 @@ function countryLookup(req, res) {
 
 function accountManagerLookup(req, res) {
 
-  if (!req.query.accountmanager || req.query.accountmanager.length === 0) {
+  if (!req.query.term || req.query.term.length === 0) {
     res.json([]);
     return;
   }
 
-  const param = req.query.accountmanager.toLocaleLowerCase();
+  const param = req.query.term.toLocaleLowerCase();
 
   rp({
     url: `${config.apiRoot}/advisor/`,
@@ -97,6 +97,24 @@ function getMetadata(req, res) {
     case 'turnover_range':
       result = metadata.TURNOVER_OPTIONS;
       break;
+    case 'role':
+      rp({
+        url: `${config.apiRoot}/metadata/role/`,
+        json: true
+      })
+        .then((response) => {
+          res.json(response);
+        });
+      return;
+    case 'title':
+      rp({
+        url: `${config.apiRoot}/metadata/title/`,
+        json: true
+      })
+        .then((response) => {
+          res.json(response);
+        });
+      return;
     case 'advisors':
       rp({
         url: `${config.apiRoot}/advisor/`,

--- a/app/controller/companycontroller.js
+++ b/app/controller/companycontroller.js
@@ -100,7 +100,7 @@ function post(req, res) {
       let errors = error.error;
       cleanErrors(errors);
 
-      res.status(400).json({errors: error.error});
+      res.status(400).json({errors});
     });
 }
 
@@ -165,7 +165,7 @@ router.get('/:company_id/unarchive', unarchive);
 router.get('/:sourceId/json?', getJson);
 router.get('/:source/:sourceId?', view);
 router.post('/:company_id/archive', archive);
-router.post(['/', '/add', '/:source/:sourceId?'], post);
+router.post(['/'], post);
 
 
 module.exports = { view, post, router };

--- a/app/controller/contactcontroller.js
+++ b/app/controller/contactcontroller.js
@@ -3,11 +3,10 @@
 'use strict';
 const express = require('express');
 const router = express.Router();
+const controllerUtils = require('../lib/controllerutils');
 
 let contactRepository = require('../repository/contactrepository');
-let companyRepository = require('../repository/companyrepository');
 
-const TEAM_OPTIONS = require('../../data/teams.json');
 const REASONS_FOR_ARCHIVE = [
   'Contact has left the company',
   'Contact does not want to be contacted',
@@ -25,8 +24,8 @@ function view(req, res) {
   contactRepository.getContact(contact_id)
     .then((contact) => {
 
-      if (contact.primary_contact_team && contact.primary_contact_team.length > 0) {
-        contact.primary_contact_team = contact.primary_contact_team.split(',');
+      if (!contact.interactions) {
+        contact.interactions = [];
       }
 
       res.render('contact/contact', { term: req.query.term, contact, REASONS_FOR_ARCHIVE });
@@ -38,75 +37,58 @@ function view(req, res) {
 
 function edit(req, res) {
 
-  if (req.body && Object.keys(req.body).length > 0) {
-    companyRepository.getDitCompany(req.body.company)
-      .then((company) => {
-        convertToFormAddress(req.body);
-        res.render('contact/contact-edit', {
-          company: company,
-          contact: req.body,
-          TEAM_OPTIONS
-        });
-      });
-    return;
-  }
+  let contactId = req.params.contact_id || null;
 
-  const contact_id = req.params.contact_id;
-
-  if (!contact_id) {
-    res.redirect('/');
-    return;
-  }
-
-  contactRepository.getContact(contact_id)
-    .then((contact) => {
-
-      convertToFormAddress(contact);
-      if (contact.primary_contact_team && contact.primary_contact_team.length > 0) {
-        contact.primary_contact_team = contact.primary_contact_team.split(',');
-      }
-
-      res.render('contact/contact-edit', { contact, TEAM_OPTIONS
-      });
-    })
-    .catch((error) => {
-      res.render('error', {error});
-    });
+  res.render('contact/contact-edit', {
+    companyId: null,
+    contactId
+  });
 }
 
 function add(req, res) {
-  let companyId = req.query.company_id;
-  if (!companyId) {
-    res.redirect('/');
-  }
+  let companyId = req.query.company_id || null;
 
-  companyRepository.getCompany(companyId)
-    .then((company) => {
-      res.render('contact/contact-edit', {
-        contact: {
-          company: company
-        },
-        formData: {},
-        TEAM_OPTIONS
-      });
-    });
+  res.render('contact/contact-edit', {
+    companyId,
+    contactId: null
+  });
+}
+
+function cleanErrors(errors) {
+  if (errors.address_1 || errors.address_2 ||
+    errors.address_town || errors.address_county ||
+    errors.address_postcode || errors.address_country)
+  {
+    errors.registered_address = ['Invalid address'];
+    delete errors.address_1;
+    delete errors.address_2;
+    delete errors.address_town;
+    delete errors.address_county;
+    delete errors.address_postcode;
+    delete errors.address_country;
+  }
 }
 
 function post(req, res) {
-  sanitizeForm(req);
-  convertFromFormAddress(req.body);
+  // Flatten selected fields
+  let contact = Object.assign({}, req.body.contact);
 
-  contactRepository.saveContact(req.body)
-    .then((savedContact) => {
-      if (req.params.contact_id) {
-        res.redirect(`/contact/${req.params.contact_id}/view`);
-      } else {
-        res.redirect(`/company/DIT/${savedContact.company}#contacts`);
-      }
+  controllerUtils.flattenIdFields(contact);
+  controllerUtils.flattenAddress(contact);
+  controllerUtils.nullEmptyFields(contact);
+
+  contact.telephone_countrycode = '+44';
+
+  contactRepository.saveContact(contact)
+    .then((data) => {
+      res.json(data);
     })
     .catch((error) => {
-      req.errors = error.response.body;
-      view(req, res);
+
+      let errors = error.error;
+      cleanErrors(errors);
+
+      res.status(400).json({errors});
     });
 
 }
@@ -125,53 +107,24 @@ function unarchive(req, res) {
     });
 }
 
+function getJson(req, res) {
+  let id = req.params.sourceId;
 
-function sanitizeForm(req) {
-  req.sanitize('primaryContactTeam').joinArray();
+  contactRepository.getContact(id)
+    .then((contact) => {
+      res.json(contact);
+    })
+    .catch((error) => {
+      res.render('error', {error});
+    });
 }
 
-function convertFromFormAddress(formData) {
-
-  if (formData.useCompanyAddress.toLocaleLowerCase() === 'no') {
-    formData.address_1 = formData['address.address1'];
-    formData.address_2 = formData['address.address2'];
-    formData.address_town = formData['address.city'];
-    formData.address_county = formData['address.county'];
-    formData.address_postcode = formData['address.postcode'];
-    formData.address_country = formData['address.country'];
-  }
-
-  delete formData['address.address1'];
-  delete formData['address.address2'];
-  delete formData['address.city'];
-  delete formData['address.county'];
-  delete formData['address.postcode'];
-  delete formData['address.country'];
-
-}
-
-function convertToFormAddress(formData) {
-  formData.address = {
-    address1: formData.address_1,
-    address2: formData.address_2,
-    city: formData.address_town,
-    county: formData.address_county,
-    postcode: formData.address_postcode,
-    country: formData.address_country
-  };
-
-  delete formData.address_1;
-  delete formData.address_2;
-  delete formData.address_town;
-  delete formData.address_county;
-  delete formData.address_postcode;
-  delete formData.address_country;
-}
 
 router.get('/add?', add);
 router.get('/:contact_id/edit', edit);
+router.get('/:sourceId/json?', getJson);
 router.get('/:contact_id/view', view);
-router.post(['/add', '/:contact_id/edit'], post);
+router.post(['/'], post);
 router.post('/:contact_id/archive', archive);
 router.get('/:contact_id/unarchive', unarchive);
 

--- a/app/javascripts/company.js
+++ b/app/javascripts/company.js
@@ -29,7 +29,7 @@ if (contacts && contacts.length > 0) {
     document.querySelector('#archived-contact-table-wrapper')
   );
 
-  let validContacts = contacts.filter((contact) => !contact.archive_date);
+  let validContacts = contacts.filter((contact) => !contact.archived_on);
   let archivedContacts = contacts.length - validContacts.length;
 
   addedCountElement.innerHTML = validContacts.length;

--- a/app/javascripts/components/address.component.js
+++ b/app/javascripts/components/address.component.js
@@ -187,7 +187,12 @@ export class AddressComponent extends Component {
 
   getPostcodeLookupSection() {
 
+    if (this.state.address.address_country === null || this.state.address.address_country.length === 0) {
+      return null;
+    }
+
     const country = this.countryForId(this.state.address.address_country);
+
     if (country && country.name && country.name === 'United Kingdom') {
       const addressSuggestions = this.addressSuggestions();
 

--- a/app/javascripts/components/contacttable.component.js
+++ b/app/javascripts/components/contacttable.component.js
@@ -73,17 +73,17 @@ class ContactTable extends Component {
 
     const link = `/contact/${contact.id}/view`;
 
-    if (this.props.archived === true && contact.archive_date !== null ||
-    this.props.archived === false && contact.archive_date === null) {
+    if (this.props.archived === true && contact.archived_on !== null ||
+    this.props.archived === false) {
 
-      let date = contact.archive_date === null ? formatDate(contact.created_date) : formatDate(contact.archive_date);
+      //let date = formatDate(contact.created_date);
 
       return (
         <tr key={contact.id}>
-          <td className="creationdate">{ date }</td>
+          <td className="creationdate"></td>
           <td className="name"><a href={link}>{ contact.first_name } { contact.last_name }</a></td>
-          <td className="title">{ contact.role }</td>
-          <td className="phone">{ contact.phone }</td>
+          <td className="title">{ contact.role.name }</td>
+          <td className="phone">{ contact.telephone_number }</td>
           <td className="email"><a href={'mailto:' + contact.email }>{ contact.email }</a></td>
         </tr>
       );
@@ -124,7 +124,7 @@ class ContactTable extends Component {
           <th
             className={this.columnClass('occupation')}
             onClick={() => {this.changeSort('occupation');}}
-          >Title</th>
+          >Role</th>
           <th
             className={this.columnClass('telephonenumber')}
             onClick={() => {this.changeSort('telephonenumber');}}

--- a/app/javascripts/components/errorlist.component.js
+++ b/app/javascripts/components/errorlist.component.js
@@ -14,6 +14,8 @@ export function errorListComponent(props) {
     );
   });
 
+  window.scrollTo(0,0);
+  
   return (
     <div className="error-summary" role="group" tabIndex="-1">
       <h1 className="heading-medium error-summary-heading" id="error-summary-heading">

--- a/app/javascripts/components/radiowithid.component.js
+++ b/app/javascripts/components/radiowithid.component.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import axios from 'axios';
 
-class RadioWithId extends Component {
+export class RadioWithIdComponent extends Component {
 
   constructor(props) {
     super(props);
@@ -19,6 +19,12 @@ class RadioWithId extends Component {
       };
     }
 
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps && nextProps.value) {
+      this.setState({value: nextProps.value});
+    }
   }
 
   getNameForId(id) {
@@ -85,7 +91,7 @@ class RadioWithId extends Component {
   }
 }
 
-RadioWithId.propTypes = {
+RadioWithIdComponent.propTypes = {
   value: React.PropTypes.string,
   url: React.PropTypes.string.isRequired,
   name: React.PropTypes.string.isRequired,
@@ -93,5 +99,3 @@ RadioWithId.propTypes = {
   label: React.PropTypes.string.isRequired,
   errors: React.PropTypes.array
 };
-
-export default RadioWithId;

--- a/app/javascripts/contactedit.js
+++ b/app/javascripts/contactedit.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {ContactForm} from './sections/contactform';
+import axios from 'axios';
+
+
+const editElement = document.getElementById('contact-form');
+const companyId = editElement.getAttribute('data-company-id');
+const contactId = editElement.getAttribute('data-contact-id');
+
+if (contactId && contactId.length > 0) {
+  axios
+    .get(`/contact/${contactId}/json`)
+    .then(result => {
+      let contact = result.data;
+
+      ReactDOM.render(
+        <div>
+          <a className="back-link" href='/'>Back to home</a>
+          <h1 className="heading-xlarge">
+            Edit contact
+          </h1>
+          <ContactForm contact={contact}/>
+        </div>,
+        editElement
+      );
+    });
+} else if (companyId && companyId.length > 0) {
+  axios
+    .get(`/company/${companyId}/json`)
+    .then(result => {
+      let company = result.data;
+
+      ReactDOM.render(
+        <div>
+          <a className="back-link" href='/'>Back to home</a>
+          <h1 className="heading-xlarge">
+            Add new contact
+          </h1>
+          <ContactForm company={company}/>
+        </div>,
+        editElement
+      );
+    });
+} else {
+    ReactDOM.render(
+      <div>
+        <a className="back-link" href='/'>Back to home</a>
+        <h1 className="heading-xlarge">
+          Add new contact
+        </h1>
+        <ContactForm/>
+      </div>,
+      editElement
+    );
+}

--- a/app/javascripts/sections/baseform.js
+++ b/app/javascripts/sections/baseform.js
@@ -1,0 +1,46 @@
+import React, { Component } from 'react';
+
+export class BaseForm extends Component {
+
+  updateField = (update) => {
+    let fieldName;
+    let value;
+
+    if (update.hasOwnProperty('target')) {
+      fieldName = update.target.name;
+      value = update.target.value;
+    } else {
+      fieldName = update.name;
+      value = update.value;
+    }
+
+    if (typeof value === 'string') {
+      if (value.toLocaleLowerCase() === 'yes') {
+        value = true;
+      } else if (value.toLocaleLowerCase() === 'no') {
+        value = false;
+      }
+    }
+
+    this.changeFormData(fieldName, value);
+  };
+
+  changeFormData = (fieldName, value) => {
+    let newFormDataState = this.state.formData;
+    newFormDataState[fieldName] = value;
+    this.setState({formData: newFormDataState });
+  };
+
+  getErrors(name) {
+    if (this.state.errors && this.state.errors[name]) {
+      return this.state.errors[name];
+    }
+    return null;
+  }
+
+  getSaving() {
+    return (
+      <div className="saving">Saving...</div>
+    );
+  }
+}

--- a/app/javascripts/sections/contactform.js
+++ b/app/javascripts/sections/contactform.js
@@ -1,0 +1,274 @@
+import React from 'react';
+import axios from 'axios';
+import {BaseForm} from './baseform';
+import {AddressComponent as Address} from '../components/address.component';
+import {AutosuggestComponent as Autosuggest} from '../components/autosuggest.component';
+import {inputTextComponent as InputText} from '../components/inputtext.component';
+import {errorListComponent as ErrorList} from '../components/errorlist.component';
+
+
+const LABELS = {
+  'company': 'Company',
+  'title': 'Title (optional)',
+  'first_name': 'First name',
+  'last_name': 'Last name',
+  'role': 'Role',
+  'telephone_number': 'Phone',
+  'email': 'Email address',
+  'address': 'Address',
+  'telephone_alternative': 'Alternative phone (optional)',
+  'email_alternative': 'Alternative email (optional)',
+  'notes': 'Notes (optional)',
+  'primary': 'Is this person a primary contact?'
+};
+
+const defaultContact = {
+  company: {
+    id: '',
+    name: ''
+  },
+  address_same_as_company: true,
+  title: {
+    id: '',
+    name: ''
+  },
+  first_name: '',
+  last_name: '',
+  role: {
+    id: '',
+    name: ''
+  },
+  telephone_number: '',
+  email: '',
+  primary: false,
+  address: {
+    address_1: '',
+    address_2: '',
+    address_town: '',
+    address_county: '',
+    address_postcode: '',
+    address_country: ''
+  },
+  telephone_alternative: '',
+  email_alternative: '',
+  notes: ''
+};
+
+function setDefaults(contact) {
+  const fieldNames = Object.keys(defaultContact);
+  for (const fieldName of fieldNames) {
+    if (!contact[fieldName]) {
+      contact[fieldName] = defaultContact[fieldName];
+    }
+  }
+}
+
+
+export class ContactForm extends BaseForm {
+
+  constructor(props) {
+    super(props);
+
+    let state = {
+      saving: false,
+      showCompanyField: true
+    };
+
+    if (props.contact) {
+      state.formData = Object.assign({}, props.contact);
+      state.showCompanyField = false;
+    } else {
+      state.formData = {};
+    }
+
+    if (props.company) {
+      state.showCompanyField = false;
+      state.formData.company = props.company;
+    }
+
+    setDefaults(state.formData);
+
+    this.state = state;
+  }
+
+  save = () => {
+    if (this.state.showAddress === false) {
+      this.state.formData.address = defaultContact.address;
+    }
+
+    axios.post('/contact/', { contact: this.state.formData })
+      .then((response) => {
+        window.location.href = `/contact/${response.data.id}/view`;
+      })
+      .catch((error) => {
+        this.setState({
+          errors: error.response.data.errors,
+          saving: false
+        });
+      });
+  };
+
+  render() {
+
+    const formData = this.state.formData;
+
+    return (
+      <div>
+        { this.state.errors &&
+        <ErrorList labels={LABELS} errors={this.state.errors}/>
+        }
+
+        { this.state.showCompanyField ?
+          <Autosuggest
+            label={LABELS.company}
+            lookupUrl='/api/suggest'
+            onChange={this.updateField}
+            errors={this.getErrors('title')}
+            name="company"
+            value={formData.company}
+          />
+          :
+          <div className="form-group">
+            <div className="form-label">Company</div>
+            <strong>{ formData.company.name }</strong>
+          </div>
+        }
+        <Autosuggest
+          label={LABELS.title}
+          suggestionUrl='/api/meta/title'
+          onChange={this.updateField}
+          errors={this.getErrors('title')}
+          name="title"
+          value={formData.title}
+        />
+        <InputText
+          label={LABELS.first_name}
+          name="first_name"
+          value={formData.first_name}
+          onChange={this.updateField}
+          errors={this.getErrors('firstName')}
+        />
+        <InputText
+          label={LABELS.last_name}
+          name="last_name"
+          value={formData.last_name}
+          onChange={this.updateField}
+          errors={this.getErrors('last_name')}
+        />
+        <Autosuggest
+          label={LABELS.role}
+          suggestionUrl='/api/meta/role'
+          onChange={this.updateField}
+          errors={this.getErrors('role')}
+          name="role"
+          value={formData.role}
+        />
+        <fieldset className="inline form-group form-group__checkbox-group form-group__radiohide">
+          <legend className="form-label">{LABELS.primary}</legend>
+          <label
+            className={formData.primary ? 'block-label selected' : 'block-label'}
+            htmlFor="primary-yes">
+            <input
+              id="primary-yes"
+              type="radio"
+              name="primary"
+              value="Yes"
+              checked={formData.primary}
+              onChange={this.updateField}
+            />
+            Yes
+          </label>
+          <label
+            className={!formData.primary ? 'block-label selected' : 'block-label'}
+            htmlFor="primary-no">
+            <input
+              id="primary-no"
+              type="radio"
+              name="primary"
+              value="No"
+              checked={!formData.primary}
+              onChange={this.updateField}
+            />
+            No
+          </label>
+        </fieldset>
+        <InputText
+          label={LABELS.telephone_number}
+          name="telephone_number"
+          value={formData.telephone_number}
+          onChange={this.updateField}
+          errors={this.getErrors('telephone_number')}
+        />
+        <InputText
+          label={LABELS.email}
+          name="email"
+          value={formData.email}
+          onChange={this.updateField}
+          errors={this.getErrors('email')}
+        />
+        <fieldset className="inline form-group form-group__checkbox-group form-group__radiohide">
+          <legend className="form-label">Is the contact's address the same as the company address?</legend>
+          <label className={this.state.formData.address_same_as_company ? 'block-label selected' : 'block-label'}>
+            <input
+              type="radio"
+              value="Yes"
+              name="address_same_as_company"
+              checked={this.state.formData.address_same_as_company}
+              onChange={this.updateField}
+            />
+            Yes
+          </label>
+          <label className={this.state.formData.address_same_as_company ? 'block-label' : 'block-label selected'}>
+            <input
+              type="radio"
+              value="No"
+              name="address_same_as_company"
+              checked={!this.state.formData.address_same_as_company}
+              onChange={this.updateField}
+            />
+            No
+          </label>
+        </fieldset>
+        { !this.state.formData.address_same_as_company &&
+          <Address
+            name='address'
+            label={LABELS.address}
+            onChange={this.updateField}
+            errors={this.getErrors('address')}
+            value={formData.address}
+          />
+        }
+        <InputText
+          label={LABELS.telephone_alternative}
+          name="telephone_alternative"
+          value={formData.telephone_alternative}
+          onChange={this.updateField}
+          errors={this.getErrors('telephone_alternative')}
+        />
+        <InputText
+          label={LABELS.email_alternative}
+          name="email_alternative"
+          value={formData.email_alternative}
+          onChange={this.updateField}
+          errors={this.getErrors('email_alternative')}
+        />
+        <div className="form-group ">
+          <label className="form-label" htmlFor="description">Notes (optional)</label>
+          <textarea
+            id="notes"
+            className="form-control"
+            name="notes"
+            rows="5"
+            onChange={this.updateField}
+            value={formData.notes}/>
+        </div>
+        <div className="button-bar">
+          <button className="button button--save" type="button" onClick={this.save}>Save</button>
+          <a className="button-link button--cancel js-button-cancel" href="/">Cancel</a>
+        </div>
+      </div>
+
+    );
+  }
+
+}

--- a/app/lib/controllerutils.js
+++ b/app/lib/controllerutils.js
@@ -77,13 +77,21 @@ function flattenIdFields(data) {
 
 function flattenAddress(data, addressName) {
 
-  if (data[`${addressName}_address`]) {
-    const address = data[`${addressName}_address`];
-    const addressKeys = Object.keys(address);
-    for (const key of addressKeys) {
-      data[`${addressName}_${key}`] = address[key];
+  if (addressName) {
+
+    if (data[`${addressName}_address`]) {
+      const address = data[`${addressName}_address`];
+      const addressKeys = Object.keys(address);
+      for (const key of addressKeys) {
+        data[`${addressName}_${key}`] = address[key];
+      }
+      delete data[`${addressName}_address`];
     }
-    delete data[`${addressName}_address`];
+  } else {
+    for (const key of Object.keys(data.address)) {
+      data[key] = data.address[key];
+    }
+    delete data.address;
   }
 }
 

--- a/app/lib/searchservice.js
+++ b/app/lib/searchservice.js
@@ -18,7 +18,7 @@ function search(query) {
 
   let options = {
     url: `${config.apiRoot}/search`,
-    body,
+    form: body,
     json: true,
     method: 'POST'
   };
@@ -27,10 +27,17 @@ function search(query) {
   return rp(options);
 }
 
-function suggestCompany(term) {
+function suggestCompany(term, types) {
+
+  if (!types) {
+    types = ['company_company'];
+  }
+
+  term += '*';
+
   let options = {
     url: `${config.apiRoot}/search`,
-    body: {term},
+    form: {term, doc_type: types},
     json: true,
     method: 'POST'
   };
@@ -38,12 +45,10 @@ function suggestCompany(term) {
   return rp(options).
     then((result) => {
       return result.hits
-        .filter(item => item._type === 'company_companieshousecompany')
         .map(hit => {
           return {
-            company_number: hit._source.company_number,
             name: hit._source.name,
-            id: hit._source.company_number,
+            id: hit._id,
             _type: hit._type
           };
         });

--- a/app/repository/companyrepository.js
+++ b/app/repository/companyrepository.js
@@ -68,7 +68,7 @@ function archiveCompany(companyId, reason) {
   let options = {
     json: true,
     body: {
-      'archive_date': moment().format('YYYY-MM-DD'),
+      'archived_on': moment().format('YYYY-MM-DD'),
       'archive_reason': reason,
       'archived_by': 'Lee Smith',
     },
@@ -84,7 +84,7 @@ function unarchiveCompany(companyId) {
   let options = {
     json: true,
     body: {
-      'archive_date': null,
+      'archived_on': null,
       'archive_reason': null,
       'archived_by': null,
     },

--- a/app/repository/contactrepository.js
+++ b/app/repository/contactrepository.js
@@ -45,7 +45,7 @@ function archiveContact(contactId, reason) {
   let options = {
     json: true,
     body: {
-      'archive_date': moment().format('YYYY-MM-DD'),
+      'archived_on': moment().format('YYYY-MM-DD'),
       'archive_reason': reason,
       'archived_by': 'Lee Smith',
     },
@@ -61,7 +61,7 @@ function unarchiveContact(contactId) {
   let options = {
     json: true,
     body: {
-      'archive_date': null,
+      'archived_on': null,
       'archive_reason': null,
       'archived_by': null,
     },

--- a/app/views/company/company-contacts.html
+++ b/app/views/company/company-contacts.html
@@ -14,7 +14,7 @@
     </div>
     <div class="column-one-third">
       <p class="actions">
-        {% if not company.archive_date %}
+        {% if not company.archived_on %}
           <a class="button button-secondary" href="/contact/add?company_id={{ company.id }}">Add new contact</a>
         {% else %}
           <a class="button button-disabled">Add new contact</a>

--- a/app/views/company/company-details.html
+++ b/app/views/company/company-details.html
@@ -140,7 +140,7 @@
       {% if not company.id %}
         <a href="#" class="button button-secondary js-button-edit">Edit company details</a>
       {% else  %}
-        {% if not company.archive_date %}
+        {% if not company.archived_on %}
           <a href="#" class="button button-secondary js-button-edit">Edit company details</a>
           <a href="#" id="archive-reveal-button" class="button button-secondary">Archive company</a>
         {% else %}

--- a/app/views/company/company-interactions.html
+++ b/app/views/company/company-interactions.html
@@ -14,7 +14,7 @@
     </div>
     <div class="column-one-third">
       <p class="actions">
-        {% if not company.archive_date %}
+        {% if not company.archived_on %}
           <a class="button button-secondary" href="/interaction/add?company_id={{ company.id }}">Add new interaction</a>
         {% else %}
           <a class="button button-disabled">Add new interaction</a>
@@ -27,7 +27,7 @@
 
 {% elif company.id and company.contacts.length > 0 %}
   <p class="actions">
-    {% if not company.archive_date %}
+    {% if not company.archived_on %}
       <a class="button button-secondary" href="/interaction/add?company_id={{ company.id }}">Add new interaction</a>
     {% else %}
       <a class="button button-disabled">Add new interaction</a>

--- a/app/views/company/company.html
+++ b/app/views/company/company.html
@@ -18,7 +18,7 @@
 
   {{ forms.errorPanel(errors) }}
   {% if company.id %}
-    {% if not company.archive_date %}
+    {% if not company.archived_on %}
       <form id="archive-details" class="hidden" action="/company/{{ company.id }}/archive" method="post">
         {{ forms.dropdown('archived_reason',
           label="Reason for archiving company",
@@ -76,7 +76,7 @@
       </div>
     {% endif %}
 
-    {% if company.id and company.contacts.length == 0 and not company.archive_date %}
+    {% if company.id and company.contacts.length == 0 and not company.archived_on %}
       <div id="tab-error-interactions" class="tabs-errors">
         <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
           <h1 class="heading-medium error-summary-heading" id="error-summary-heading">

--- a/app/views/contact/contact-details.html
+++ b/app/views/contact/contact-details.html
@@ -2,30 +2,30 @@
   <tbody>
     <tr>
       <th width="30%">Company</th>
-      <td><a href="/company/DIT/{{ contact.company.id }}">{{ contact.company.registered_name }}</a></td>
+      <td><a href="/company/DIT/{{ contact.company.id }}">{{ contact.company.name }}</a></td>
     </tr>
     <tr>
     <tr>
       <th>Title</th>
-      <td>{{ contact.title }}</td>
+      <td>{{ contact.title.name }}</td>
     </tr>
     <tr>
       <th>Role</th>
-      <td>{{ contact.role }}</td>
+      <td>{{ contact.role.name }}</td>
     </tr>
-    {% if contact.primary_contact_team %}
+    {% if contact.teams and contact.teams.length > 0 %}
       <tr>
         <th>Teams</th>
         <td>
-          {% for primaryTeam in contact.primary_contact_team %}
-            <div>{{ primaryTeam }}</div>
+          {% for team in contact.teams %}
+            <div>{{ team.name }}</div>
           {% endfor %}
         </td>
       </tr>
     {% endif %}
     <tr>
       <th>Phone number</th>
-      <td>{{ contact.phone }}</td>
+      <td>{{ contact.telephone_number }}</td>
     </tr>
     <tr>
       <th>Email</th>
@@ -41,11 +41,11 @@
     {% endif %}
     <tr>
       <th>Alternative phone</th>
-      <td>{{ contact.alt_phone }}</td>
+      <td>{{ contact.telephone_alternative }}</td>
     </tr>
     <tr>
       <th>Alternative email</th>
-      <td>{{ contact.alt_email }}</td>
+      <td>{{ contact.email_alternative }}</td>
     </tr>
     <tr>
       <th>Notes</th>
@@ -55,8 +55,8 @@
 </table>
 
 <div class="button-bar">
-  {% if not contact.company.archive_date %}
-    {% if not contact.archive_date %}
+  {% if not contact.company.archived_on %}
+    {% if not contact.archived_on %}
       <a href="/contact/{{ contact.id }}/edit" class="button button-secondary">Edit contact details</a>
       <a href="#" id="archive-reveal-button" class="button button-secondary">Archive contact</a>
     {% else %}
@@ -64,7 +64,7 @@
       <a href="/contact/{{ contact.id }}/unarchive" class="button button-secondary">Unarchive now</a>
     {% endif %}
   {% else %}
-    {% if not contact.archive_date %}
+    {% if not contact.archived_on %}
       <a class="button button-disabled">Edit contact details</a>
       <a id="archive-reveal-button" class="button button-disabled">Archive contact</a>
     {% else %}

--- a/app/views/contact/contact-edit.html
+++ b/app/views/contact/contact-edit.html
@@ -1,76 +1,8 @@
 {% extends "../layouts/ukti-search-header.html" %}
-{% import "macros/forms.html" as forms %}
 
 {% block main %}
-
-  {% if contact.id %}
-    {% set backUrl = "/contact/" + contact.id + "/view" %}
-    <a class="back-link" href="{{ backUrl }}">Back to contact</a>
-    {{ forms.errorPanel(errors) }}
-    <h1 class="heading-xlarge record-title">
-      Edit contact details
-    </h1>
-  {% else %}
-    {% set backUrl = "/company/DIT/" +  contact.company.id + "#contacts" %}
-    <a class="back-link" href="{{ backUrl }}">Back to company</a>
-    {{ forms.errorPanel(errors) }}
-    <h1 class="heading-xlarge record-title">
-      Add contact
-    </h1>
-  {% endif %}
-
-  <form method="post">
-    <input type="hidden" name="id" value="{{ contact.id }}"/>
-    <input type="hidden" name="company" value="{{ contact.company.id }}"/>
-    <div class="form-group">
-      <div class="form-label">Company</div>
-      <strong>{{ contact.company.registered_name }}</strong>
-    </div>
-    <div class="form-section form-section--compact">{{ forms.textbox('title', label="Title (optional)", value=contact.title, error=errors.title) }}
-      {{ forms.textbox('first_name', label="First name", value=contact.first_name, error=errors.first_name) }}
-      {{ forms.textbox('last_name', label="Last name", value=contact.last_name, error=errors.last_name) }}
-      {{ forms.textbox('role', label="Role", value=contact.role, error=errors.role) }}
-      {% if contact.primary_contact_team and contact.primary_contact_team.length > 0 or errors.primary_contact_team %}
-        {% set show_primary_contact = 'Yes' %}
-      {% else %}
-        {% set show_primary_contact = 'No' %}
-      {% endif %}
-      {% call forms.yesNoHidden('show_primary_contact', label="Is this person a primary contact?", radioValue=show_primary_contact, error=errors.primary_contact_team) -%}
-        {{ forms.addAnotherDropdown('primary_contact_team',
-          label="Team name",
-          addLabel="team",
-          hint="Provide the name of the team for which this contact is listed as a primary contact",
-          emptyLabel="Select a team",
-          values=contact.primary_contact_team,
-          options=TEAM_OPTIONS,
-          error=errors.primary_contact_team)
-        }}
-      {%- endcall %}
-      {{ forms.textbox('phone', label="Phone", value=contact.phone, error=errors.phone) }}
-      {{ forms.textbox('email', label="Email address", value=contact.email, error=errors.email) }}
-    </div>
-
-    {% if contact.address and contact.address.country and contact.address.country.length > 0 or errors.contact_address %}
-      {% set useCompanyAddress = 'No' %}
-    {% else %}
-      {% set useCompanyAddress = 'Yes' %}
-    {% endif %}
-    {% call forms.yesNoHidden('useCompanyAddress', label="Is the contact’s address the same as the company address?", radioValue=useCompanyAddress, revealFor="No") -%}
-      {{ forms.address('address',
-        label="Address",
-        addressValue=contact.address,
-        optionalNonUk='yes',
-        optional='yes',
-        error=errors.address)
-      }}
-    {%- endcall %}
-
-    <div class="form-section form-section--compact">
-      {{ forms.textbox('alt_phone', label="Alternative phone (optional)", value=contact.alt_phone, error=errors.alt_phone) }}
-      {{ forms.textbox('alt_email', label="Alternative email (optional)", value=contact.alt_email, error=errors.alt_email) }}
-      {{ forms.textarea('notes', label="Notes (optional)", value=contact.notes, error=errors.notes) }}
-    </div>
-    {{ forms.save(backUrl=backUrl) }}
-
-  </form>
+  <div id="contact-form"
+       data-contact-id="{{ contactId }}"
+       data-company-id="{{ companyId }}">Loading...</div>
+  <script src="/javascripts/contactedit.bundle.js"></script>
 {% endblock %}

--- a/app/views/contact/contact-interactions.html
+++ b/app/views/contact/contact-interactions.html
@@ -14,7 +14,7 @@
     </div>
     <div class="column-one-third">
       <p class="actions">
-        {% if not contact.archive_date and not contact.company.archive_date %}
+        {% if not contact.archived %}
           <a class="button button-secondary" href="/interaction/add?contact_id={{ contact.id }}">Add new interaction</a>
         {% else %}
           <a class="button button-disabled">Add new interaction</a>
@@ -26,7 +26,7 @@
 
 {% else %}
   <p class="actions">
-    {% if not contact.archive_date %}
+    {% if not contact.archived %}
       <a class="button button-secondary" href="/interaction/add?contact_id={{ contact.id }}">Add new interaction</a>
     {% else %}
       <a class="button button-disabled">Add new interaction</a>

--- a/app/views/contact/contact.html
+++ b/app/views/contact/contact.html
@@ -9,15 +9,15 @@
   {% endif %}
   <h1 class="heading-xlarge record-title">
     {{ contact.first_name }} {{ contact.last_name }}
-    {% if contact.archive_date %}
+    {% if contact.archived %}
       <span class="status-badge status-badge--archived">Archived</span>
-    {% elseif contact.primary_contact_team and contact.primary_contact_team.length > 0 %}
+    {% elseif contact.primary %}
       <span class="status-badge status-badge--primary-contact">Primary</span>
     {% endif %}
 
   </h1>
 
-  {% if not contact.archive_date %}
+  {% if not contact.archived %}
     <form id="archive-details" class="hidden" action="/contact/{{ contact.id }}/archive" method="post">
       {{ forms.dropdown('archive_reason',
       label="Reason for archiving contact",
@@ -36,7 +36,7 @@
     </form>
   {% else %}
     <p class="indented-info">
-      This contact has been archived on {{ contact.archive_date | formatDate }} by <a href="#">{{ contact.archived_by }}</a>.<br/>
+      This contact has been archived on {{ contact.archived_on | formatDate }} by <a href="#">{{ contact.archived_by }}</a>.<br/>
       Reason: {{ contact.archive_reason }}
     </p>
     <hr/>

--- a/app/views/interaction/interaction-details.html
+++ b/app/views/interaction/interaction-details.html
@@ -69,7 +69,7 @@
 
     </tbody>
   </table>
-  {% if not interaction.company.archive_date and not interaction.contact.archive_date %}
+  {% if not interaction.company.archived %}
     <a href="/interaction/{{ interaction.id }}/edit" class="button button-secondary">Edit interaction details</a>
   {% else %}
     <a class="button button-disabled">Edit interaction details</a>

--- a/app/views/search/results.html
+++ b/app/views/search/results.html
@@ -7,14 +7,12 @@
   </span>
 </div>
 <ol class="results-list">
-  {{ result.hits | log | safe }}
   {% for hit in result.hits %}
     {% if hit._type == 'company_contact' %}
       {{ resultTypes.contactresult(hit._id, hit._source, params.term, hit._type) }}
     {% elseif hit._type == 'company_companieshousecompany' or hit._type == 'company_company' %}
       {{ resultTypes.companyresult(hit._id, hit._source, params.term, hit._type) }}
     {% endif %}
-
   {% endfor %}
 </ol>
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp-util": "^3.0.7",
     "jquery": "^3.1.0",
     "json-loader": "^0.5.4",
+    "lodash": "^4.16.4",
     "moment": "^2.14.1",
     "morgan": "1.7.0",
     "nunjucks": "^2.4.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
     facets: `${paths.sourceJS}/facets.js`,
     datahub: `${paths.sourceJS}/datahub.js`,
     companyadd_react: `${paths.sourceJS}/companyadd.js`,
+    contactedit: `${paths.sourceJS}/contactedit.js`
   },
   output: {
     path: paths.outputJS,


### PR DESCRIPTION
- Refactored react forms to share common code. 
- Refactored react forms to use common field update method. 
- Lookup advisors instead of download list
- Company suggest filters suggestions to just include DIT companies

Page can be called with : 
- /contact/add  :  Plain contact add and user has to enter company into autosuggest field
- /contact/add?company_id=x   :  Contact add but the company name is displayed and not editable and contact gets added to that company. Called when selecting add contact within a company record.
- /contact/:id/view : View the contact
- /contact/:id/edit  : Edit the contact

Currently contact list doesn't shown role as this is too nested. Will create a separate branch to improve the overall company viewing experience and fix the table of contacts.
