### PR TITLE
Refactor react forms to use inline JSON data to cut down on calls

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -65,7 +65,7 @@
     "no-unused-vars": [2, "all"],
     "no-mixed-requires": [1, true],
     "max-depth": [1, 5],
-    "max-len": [1, 120, 4],
+    "max-len": [1, 240, 4],
     "max-params": [1, 6],
     "max-statements": [1, 20],
     "no-else-return": 1,

--- a/app/controller/companycontroller.js
+++ b/app/controller/companycontroller.js
@@ -185,7 +185,7 @@ function getJson(req, res) {
 router.get('/add', add);
 router.get('/json/:company_id', getJson);
 router.get('/:company_id/unarchive', unarchive);
-router.get(['/:sourceId/json?', '/:source/:sourceId/json?'], getJson);
+router.get('/:source/:sourceId/json?', getJson);
 router.get('/:source/:sourceId?', view);
 router.post('/:company_id/archive', archive);
 router.post(['/'], post);

--- a/app/controller/companycontroller.js
+++ b/app/controller/companycontroller.js
@@ -7,6 +7,27 @@ const metadata = require('../lib/metadata');
 const companyRepository = require('../repository/companyrepository');
 const controllerUtils = require('../lib/controllerutils');
 
+// Add some extra default info into the company to make it easier to edit
+function postProcessCompany(company) {
+  if (!company.export_to_countries || company.export_to_countries.length === 0) {
+    company.export_to_countries = [{id: null, name: ''}];
+  }
+  if (!company.future_interest_countries || company.future_interest_countries.length === 0) {
+    company.future_interest_countries = [{id: null, name: ''}];
+  }
+
+  if (company.trading_address && !company.trading_address.address_country) {
+    company.trading_address = {
+      address_1: '',
+      address_2: '',
+      address_town: '',
+      address_county: '',
+      address_postcode: '',
+      address_country: null
+    };
+  }
+}
+
 function add(req, res) {
   res.render('react', { app: 'companyadd_react'});
 }
@@ -62,6 +83,7 @@ function view(req, res) {
 
   companyRepository.getCompany(id, source)
     .then((company) => {
+      postProcessCompany(company);
       let formData;
 
       if (!req.body || Object.keys(req.body).length === 0) {
@@ -163,7 +185,7 @@ function getJson(req, res) {
 router.get('/add', add);
 router.get('/json/:company_id', getJson);
 router.get('/:company_id/unarchive', unarchive);
-router.get(['/:sourceId/json?','/:source/:sourceId/json?'], getJson);
+router.get(['/:sourceId/json?', '/:source/:sourceId/json?'], getJson);
 router.get('/:source/:sourceId?', view);
 router.post('/:company_id/archive', archive);
 router.post(['/'], post);

--- a/app/controller/contactcontroller.js
+++ b/app/controller/contactcontroller.js
@@ -7,6 +7,7 @@ const controllerUtils = require('../lib/controllerutils');
 const userLeads = require( '../lib/userLeads' );
 
 let contactRepository = require('../repository/contactrepository');
+let companyRepository = require('../repository/companyrepository');
 
 const REASONS_FOR_ARCHIVE = [
   'Contact has left the company',
@@ -38,12 +39,28 @@ function view(req, res) {
 
 function edit(req, res) {
 
-  let contactId = req.params.contact_id || null;
+  const contact_id = req.params.contact_id;
 
-  res.render('contact/contact-edit', {
-    companyId: null,
-    contactId
-  });
+  if (!contact_id) {
+    res.redirect('/');
+  }
+
+  contactRepository.getContact(contact_id)
+    .then((contact) => {
+
+      if (!contact.interactions) {
+        contact.interactions = [];
+      }
+
+      res.render('contact/contact-edit', {
+        term: req.query.term,
+          company: null,
+        contact
+      });
+    })
+    .catch((error) => {
+      res.render('error', {error});
+    });
 }
 
 function add(req, res) {
@@ -52,14 +69,13 @@ function add(req, res) {
   let leadId = req.query.lead;
   let userId = req.session.userId;
   let viewModel = {
-        companyId,
-        contactId: null
-      };
+    company: null,
+    contact: null
+  };
 
   function render( data ){
 
     if (data) {
-
       Object.assign( viewModel, data );
     }
 
@@ -69,12 +85,15 @@ function add(req, res) {
   if (leadId && userId) {
 
     userLeads.getById( userId, leadId ).then( ( lead ) => {
-
       render( { lead } );
-    } );
+    });
 
+  } else if (companyId) {
+    companyRepository.getDitCompany(companyId)
+      .then((company) => {
+        render({company});
+      });
   } else {
-
     render();
   }
 }

--- a/app/controller/contactcontroller.js
+++ b/app/controller/contactcontroller.js
@@ -161,22 +161,9 @@ function unarchive(req, res) {
     });
 }
 
-function getJson(req, res) {
-  let id = req.params.sourceId;
-
-  contactRepository.getContact(id)
-    .then((contact) => {
-      res.json(contact);
-    })
-    .catch((error) => {
-      res.render('error', {error});
-    });
-}
-
 
 router.get('/add?', add);
 router.get('/:contact_id/edit', edit);
-router.get('/:sourceId/json?', getJson);
 router.get('/:contact_id/view', view);
 router.post(['/'], post);
 router.post('/:contact_id/archive', archive);

--- a/app/controller/interactioncontroller.js
+++ b/app/controller/interactioncontroller.js
@@ -4,6 +4,9 @@
 const express = require('express');
 const router = express.Router();
 const interactionRepository = require('../repository/interactionrepository');
+const contactRepository = require('../repository/contactrepository');
+const companyRepository = require('../repository/companyrepository');
+
 const controllerUtils = require('../lib/controllerutils');
 
 function view(req, res) {
@@ -29,11 +32,14 @@ function view(req, res) {
 function edit(req, res) {
   let interactionId = req.params.interaction_id || null;
 
-  res.render('interaction/interaction-edit', {
-    companyId: null,
-    contactId: null,
-    interactionId
-  });
+  interactionRepository.getInteraction(interactionId)
+    .then((interaction) => {
+      res.render('interaction/interaction-edit', {
+        company: null,
+        contact: null,
+        interaction
+      });
+    });
 }
 
 function add(req, res) {
@@ -41,11 +47,28 @@ function add(req, res) {
   const companyId = req.query.company_id;
   const contactId = req.query.contact_id;
 
-  res.render('interaction/interaction-edit', {
-    companyId,
-    contactId,
-    interactionId: null
-  });
+  if (contactId && contactId.length > 0) {
+    contactRepository.getContact(contactId)
+      .then((contact) => {
+        res.render('interaction/interaction-edit', {
+          company: contact.company,
+          contact,
+          interactionId: null
+        });
+      });
+  } else if (companyId && companyId.length > 0) {
+    companyRepository.getDitCompany(companyId)
+      .then((company) => {
+        res.render('interaction/interaction-edit', {
+          company,
+          contact: null,
+          interactionId: null
+        });
+      });
+  } else {
+    res.redirect('/');
+  }
+
 }
 
 function post(req, res) {

--- a/app/controller/interactioncontroller.js
+++ b/app/controller/interactioncontroller.js
@@ -88,28 +88,10 @@ function post(req, res) {
     });
 }
 
-function getJson(req, res) {
-  let id = req.params.sourceId;
-
-  interactionRepository.getInteraction(id)
-    .then((interaction) => {
-
-      if (interaction.dit_advisor && interaction.dit_advisor.id) {
-        interaction.dit_advisor.name = `${interaction.dit_advisor.first_name} ${interaction.dit_advisor.last_name}`;
-      }
-
-      res.json(interaction);
-    })
-    .catch((error) => {
-      res.render('error', {error});
-    });
-}
-
 
 router.get('/add?', add);
 router.get('/:interaction_id/edit', edit);
 router.get('/:interaction_id/view', view);
-router.get('/:sourceId/json?', getJson);
 router.post('/', post);
 
 module.exports = {

--- a/app/javascripts/components/companyinteractiontable.component.js
+++ b/app/javascripts/components/companyinteractiontable.component.js
@@ -144,8 +144,7 @@ class CompanyInteractionTable extends Component {
 }
 
 CompanyInteractionTable.propTypes = {
-  company: React.PropTypes.object.isRequired,
-  interactions: React.PropTypes.array
+  interactions: React.PropTypes.array.isRequired
 };
 
 export default CompanyInteractionTable;

--- a/app/javascripts/components/contacttable.component.js
+++ b/app/javascripts/components/contacttable.component.js
@@ -119,8 +119,7 @@ class ContactTable extends Component {
 }
 
 ContactTable.propTypes = {
-  company: React.PropTypes.object.isRequired,
-  contacts: React.PropTypes.array,
+  contacts: React.PropTypes.array.isRequired,
   archived: React.PropTypes.bool
 };
 

--- a/app/javascripts/components/didyoumeancompany.component.js
+++ b/app/javascripts/components/didyoumeancompany.component.js
@@ -5,7 +5,7 @@ import axios from 'axios';
 import {debounce} from 'lodash';
 
 const getSuggestionValue = suggestion => suggestion.name;
-const baseUrl='/api/suggest';
+const baseUrl = '/api/suggest';
 
 
 export class DidYouMeanCompanyComponent extends Component {
@@ -14,7 +14,7 @@ export class DidYouMeanCompanyComponent extends Component {
     super(props);
 
     this.state = {
-      selected: {id:'', name:''},
+      selected: { id: '', name: '' },
       visibleSuggestions: [],
       value: props.value || '',
       didYouMeanSuggestion: null
@@ -77,10 +77,7 @@ export class DidYouMeanCompanyComponent extends Component {
 
     if (!company) return null;
 
-    let name;
-    let type;
-    let id;
-    let addressStr;
+    let name, type, id, addressStr;
 
     if (!company.id && company.ch && company.ch.id) {
       addressStr = company.ch.registered_address_1;

--- a/app/javascripts/forms/companyform.js
+++ b/app/javascripts/forms/companyform.js
@@ -234,6 +234,7 @@ export class CompanyForm extends BaseForm {
           label={LABELS.name}
           onChange={this.updateField}
           errors={this.getErrors('name')}
+          value={formData.name}
         />
         <fieldset className="inline form-group form-group__checkbox-group form-group__radiohide">
           <legend className="form-label">Is the business based in the UK?</legend>

--- a/app/javascripts/forms/contactform.js
+++ b/app/javascripts/forms/contactform.js
@@ -78,7 +78,7 @@ export class ContactForm extends BaseForm {
 
     if (props.lead) {
 
-      let lead = JSON.parse( props.lead );
+      let lead = props.lead;
 
       state.formData.first_name = lead.firstName;
       state.formData.last_name = lead.lastName;

--- a/app/javascripts/forms/interactionform.js
+++ b/app/javascripts/forms/interactionform.js
@@ -66,11 +66,6 @@ export class InteractionForm extends BaseForm {
       state.formData = props.interaction;
       state.showCompanyField = false;
       state.showContactField = false;
-    } else if (props.company) {
-      state.formData = {
-        company: props.company,
-      };
-      state.showCompanyField = false;
     } else if (props.contact) {
       state.formData = {
         company: props.contact.company,
@@ -78,6 +73,11 @@ export class InteractionForm extends BaseForm {
       };
       state.showCompanyField = false;
       state.showContactField = false;
+    } else if (props.company) {
+      state.formData = {
+        company: props.company,
+      };
+      state.showCompanyField = false;
     } else {
       state.formData = {};
     }

--- a/app/javascripts/pages/company.js
+++ b/app/javascripts/pages/company.js
@@ -14,18 +14,16 @@ const archiveButton = document.getElementById('archive-reveal-button');
 const cancelButton = document.getElementById('cancel-archive-button');
 const archiveReasonElement = document.getElementById('archive_reason');
 const archiveReasonGroup = document.getElementById('archive_reason-wrapper');
-import axios from 'axios';
-
 
 
 if (contacts && contacts.length > 0) {
   ReactDOM.render(
-    <ContactTable contacts={contacts} company={company} archived={false} />,
+    <ContactTable contacts={contacts} archived={false} />,
     document.querySelector('#contact-table-wrapper')
   );
 
   ReactDOM.render(
-    <ContactTable contacts={contacts} company={company} archived />,
+    <ContactTable contacts={contacts} archived />,
     document.querySelector('#archived-contact-table-wrapper')
   );
 
@@ -102,37 +100,4 @@ $('.searchbar').each((index, element) => {
 });
 new Tabs('.js-tabs');
 
-
-const editElement = document.getElementById('company-edit');
-
-
-function postProcessCompany(company) {
-  if (!company.export_to_countries || company.export_to_countries.length === 0) {
-    company.export_to_countries = [{id: null, name: ''}];
-  }
-  if (!company.future_interest_countries || company.future_interest_countries.length === 0) {
-    company.future_interest_countries = [{id: null, name: ''}];
-  }
-
-  if (company.trading_address && !company.trading_address.address_country) {
-    company.trading_address = {
-      address_1: '',
-      address_2: '',
-      address_town: '',
-      address_county: '',
-      address_postcode: '',
-      address_country: null
-    };
-  }
-
-}
-
-const companyId = editElement.getAttribute('data-company-id');
-
-axios
-  .get(`/company/company_company/${companyId}/json`)
-  .then(result => {
-    let company = result.data;
-    postProcessCompany(company);
-    ReactDOM.render(<CompanyForm company={company}/>, editElement);
-  });
+ReactDOM.render(<CompanyForm company={company}/>, document.getElementById('company-edit'));

--- a/app/javascripts/pages/contactedit.js
+++ b/app/javascripts/pages/contactedit.js
@@ -1,66 +1,36 @@
+/* eslint-disable max-len */
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {ContactForm} from '../forms/contactform';
-import axios from 'axios';
 
 const editElement = document.getElementById('contact-form');
-const contactId = editElement.getAttribute('data-contact-id');
-const companyId = editElement.getAttribute('data-company-id');
-
-function getBackLink(opts) {
-
-  // if called with a company id, go back to company
-  if (opts.company) {
-    return {
-      url: `/company/company_company/${opts.company.id}#contacts`,
-      title: 'company'
-    };
-  } else if (opts.contact) {
-    return {
-      url: `/contact/${opts.contact.id}/view`,
-      title: 'contact'
-    };
-  } else if (opts.lead) {
-    return null;
-  }
-
-  return {url: '/', title: 'home'};
-}
+const contact = editElement.getAttribute('data-contact').length > 0 ? JSON.parse(editElement.getAttribute('data-contact')) : null;
+const company = editElement.getAttribute('data-company').length > 0 ? JSON.parse(editElement.getAttribute('data-company')) : null;
+const lead = editElement.getAttribute('data-lead').length > 0 ? JSON.parse(editElement.getAttribute('data-lead')) : null;
+let backUrl, backTitle, title;
 
 
-function render( opts = {} ){
-
-  const heading = ( opts.heading || 'Add new contact' );
-  const lead = editElement.getAttribute( 'data-lead' );
-  const back = getBackLink(opts);
-
-
-  ReactDOM.render(
-    <div>
-      {back &&
-        <a className="back-link" href={back.url}>Back to {back.title}</a>
-      }
-      <h1 className="heading-xlarge">
-        { heading }
-      </h1>
-      <ContactForm contact={opts.contact} company={opts.company} lead={lead}/>
-    </div>,
-    editElement
-  );
-}
-
-if (contactId && contactId.length > 0) {
-  axios
-    .get(`/contact/${contactId}/json`)
-    .then(result => {
-      render({ heading: 'Edit contact', contact: result.data });
-    });
-} else if (companyId && companyId.length > 0) {
-  axios
-    .get(`/company/company_company/${companyId}/json`)
-    .then(result => {
-      render({ company: result.data });
-    });
+if (company) {
+  backUrl = `/company/company_company/${company.id}#contacts`;
+  backTitle = 'company';
+  title = 'Add new contact';
+} else if (contact) {
+  backUrl = `/contact/${contact.id}/view`;
+  backTitle = 'contact';
+  title = 'Edit contact';
 } else {
-    render();
+  backUrl = '/';
+  backTitle = 'home';
+  title = 'Add contact';
 }
+
+
+ReactDOM.render(
+  <div>
+    <a className="back-link" href={backUrl}>Back to {backTitle}</a>
+    <h1 className="heading-xlarge">{ title }</h1>
+    <ContactForm contact={contact} company={company} lead={lead}/>
+  </div>,
+  editElement
+);

--- a/app/javascripts/pages/interactionedit.js
+++ b/app/javascripts/pages/interactionedit.js
@@ -1,80 +1,42 @@
+/* eslint-disable max-len */
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {InteractionForm} from '../forms/interactionform';
-import axios from 'axios';
-
 
 const editElement = document.getElementById('interaction-form');
-const companyId = editElement.getAttribute('data-company-id');
-const contactId = editElement.getAttribute('data-contact-id');
-const interactionId = editElement.getAttribute('data-interaction-id');
+const contact = editElement.getAttribute('data-contact').length > 0 ? JSON.parse(editElement.getAttribute('data-contact')) : null;
+const company = editElement.getAttribute('data-company').length > 0 ? JSON.parse(editElement.getAttribute('data-company')) : null;
+const interaction = editElement.getAttribute('data-interaction').length > 0 ? JSON.parse(editElement.getAttribute('data-interaction')) : null;
+let backUrl, backTitle, title;
 
-function getBackLink(opts) {
-
-  // if called with a company id, go back to company
-  if (opts.company) {
-    return {
-      url: `/company/company_company/${opts.company.id}#contacts`,
-      title: 'company'
-    };
-  } else if (opts.contact) {
-    return {
-      url: `/contact/${opts.contact.id}/view`,
-      title: 'contact'
-    };
-  } else if (opts.interaction) {
-    return {
-      url: `/interaction/${opts.interaction.id}/view`,
-      title: 'interaction'
-    };
-  }
-
-  return {url: '/', title: 'home'};
-}
-
-function render( opts = {} ){
-
-  const heading = ( opts.heading || 'Add new interaction' );
-  const back = getBackLink(opts);
-
-  ReactDOM.render(
-    <div>
-      {back &&
-        <a className="back-link" href={back.url}>Back to {back.title}</a>
-      }
-      <h1 className="heading-xlarge">
-        { heading }
-      </h1>
-      <InteractionForm
-        company={opts.company}
-        contact={opts.contact}
-        interaction={opts.interaction}
-      />
-
-    </div>,
-    editElement
-  );
-}
-
-
-if (interactionId && interactionId.length > 0) {
-  axios
-    .get(`/interaction/${interactionId}/json`)
-    .then(result => {
-      render({heading: 'Edit interaction', interaction: result.data});
-    });
-} else if (companyId && companyId.length > 0) {
-  axios
-    .get(`/company/company_company/${companyId}/json`)
-    .then(result => {
-      render({heading: 'Add interaction', company: result.data});
-    });
-} else if (contactId && contactId.length > 0) {
-  axios
-    .get(`/contact/${contactId}/json`)
-    .then(result => {
-      render({heading: 'Add interaction', contact: result.data});
-    });
+if (contact) {
+  backUrl = `/contact/${contact.id}/view#interactions`;
+  backTitle = 'contact';
+  title = 'Add new interaction';
+} else if (company) {
+  backUrl = `/company/company_company/${company.id}#interactions`;
+  backTitle = 'company';
+  title = 'Add new interaction';
+} else if (interaction) {
+  backUrl = `/interaction/${interaction.id}/view`;
+  backTitle = 'interaction';
+  title = 'Edit interaction';
 } else {
-  render();
+  backUrl = '/';
+  backTitle = 'home';
+  title = 'Add contact';
 }
+
+ReactDOM.render(
+  <div>
+    <a className="back-link" href={backUrl}>Back to {backTitle}</a>
+    <h1 className="heading-xlarge">{title}</h1>
+    <InteractionForm
+      company={company}
+      contact={contact}
+      interaction={interaction}
+    />
+  </div>,
+  editElement
+);

--- a/app/views/company/company-edit.html
+++ b/app/views/company/company-edit.html
@@ -1,1 +1,1 @@
-<div id="company-edit" data-company-id="{{ company.id }}">Loading...</div>
+<div id="company-edit">Loading...</div>

--- a/app/views/contact/contact-edit.html
+++ b/app/views/contact/contact-edit.html
@@ -2,8 +2,8 @@
 
 {% block main %}
   <div id="contact-form"
-       data-contact-id="{{ contactId }}"
-       data-company-id="{{ companyId }}"
+       data-contact='{{ contact | dump | safe }}'
+       data-company='{{ company | dump | safe }}'
        data-lead='{{ lead | dump | safe }}'>Loading...</div>
   <script src="/javascripts/contactedit.bundle.js"></script>
 {% endblock %}

--- a/app/views/interaction/interaction-edit.html
+++ b/app/views/interaction/interaction-edit.html
@@ -2,8 +2,8 @@
 
 {% block main %}
   <div id="interaction-form"
-       data-contact-id="{{ contactId }}"
-       data-company-id="{{ companyId }}"
-       data-interaction-id="{{ interactionId }}">Loading...</div>
+       data-contact='{{ contact | dump | safe }}'
+       data-company='{{ company | dump | safe }}'
+       data-interaction='{{ interaction | dump | safe }}'>Loading...</div>
   <script src="/javascripts/interactionedit.bundle.js"></script>
 {% endblock %}


### PR DESCRIPTION
Company form doesn't change much as it already has the company value set globally in the page (yes that will change).
Changed contact and interaction to use a value in the markup instead of calls to the server, and also changed the leads method slightly so that form components always get objects and it the outer 'app' that prepares the data.