### PR TITLE
Load metadata before starting the app

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,6 +26,7 @@ const customValidators = require('./app/lib/validators');
 const customSanitizers = require('./app/lib/sanitizers');
 const filters = require('./app/lib/nunjuckfilters');
 const auth = require( './app/middleware/auth');
+let metadata = require( './app/lib/metadata' );
 
 const app = express();
 const isDev = app.get('env') === 'development';
@@ -142,6 +143,20 @@ app.get('/', function(req, res) {
   res.render('index');
 });
 
-app.listen(config.port, function(){
-	console.log('app listening on port %s', config.port);
-});
+metadata.fetchAll( ( errors ) => {
+
+  if( errors ){
+
+    console.log( 'Unable to load all metadata, cannot start app' );
+
+    for( let err of errors ){
+      throw err;
+    }
+
+  } else {
+
+    app.listen(config.port, function(){
+      console.log('app listening on port %s', config.port);
+    });
+  }
+} );

--- a/app/lib/metadata.js
+++ b/app/lib/metadata.js
@@ -1,65 +1,68 @@
 'use strict';
-const rp = require('request-promise');
+
+const request = require('request-promise');
 const config = require('../../config');
 
-rp({
-  url: `${config.apiRoot}/metadata/sector/`,
-  json: true
-})
+function getMetadata( path, key ){
+
+  let url = `${config.apiRoot}/metadata/${ path }`;
+
+  return request({
+    url,
+    json: true
+  })
   .then((data) => {
-    module.exports.SECTOR_OPTIONS = data;
-  });
+
+    module.exports[ key ] = data;
+
+  }).catch( ( err ) => {
+
+    console.error( 'Error fetching metadata for url: %s', url );
+    throw err;
+  } );
+}
+
+const metadataItems = [
+  [ 'sector/', 'SECTOR_OPTIONS' ],
+  [ 'turnover', 'TURNOVER_OPTIONS' ],
+  [ 'uk-region', 'REGION_OPTIONS' ],
+  [ 'country', 'COUNTRYS' ],
+  [ 'employee-range', 'EMPLOYEE_OPTIONS' ],
+  [ 'business-type', 'TYPES_OF_BUSINESS' ],
+  [ 'team', 'TEAMS' ]
+];
+
+
+module.exports.fetchAll = function( cb ){
+
+  let caughtErrors;
+  let totalRequests = 0;
+  let completeRequests = 0;
+
+  function checkResults(){
+
+    completeRequests++;
+
+    if( completeRequests === totalRequests ){
+      console.log( 'All metadata requests complete' );
+      cb( caughtErrors );
+    }
+  }
+
+  for( let item of metadataItems ){
+
+    totalRequests++;
+
+    getMetadata( item[ 0 ], item[ 1 ] ).then( checkResults ).catch( ( err ) => {
+
+      caughtErrors = caughtErrors || [];
+      caughtErrors.push( err );
+      checkResults();
+    } );
+  }
+};
 
 module.exports.REASONS_FOR_ARCHIVE = [
   'Company is dissolved',
   'Other'
 ];
-
-rp({
-  url: `${config.apiRoot}/metadata/turnover`,
-  json: true
-})
-  .then((data) => {
-    module.exports.TURNOVER_OPTIONS = data;
-  });
-
-
-rp({
-  url: `${config.apiRoot}/metadata/uk-region`,
-  json: true
-})
-.then((data) => {
-    module.exports.REGION_OPTIONS = data;
-});
-
-rp({
-  url: `${config.apiRoot}/metadata/country`,
-  json: true
-})
-.then((data) => {
-    module.exports.COUNTRYS = data;
-});
-
-rp({
-  url: `${config.apiRoot}/metadata/employee-range`,
-  json: true
-})
-.then((data) => {
-    module.exports.EMPLOYEE_OPTIONS = data;
-});
-
-rp({
-  url: `${config.apiRoot}/metadata/business-type`,
-  json: true
-})
-.then((data) => {
-  module.exports.TYPES_OF_BUSINESS = data;
-});
-
-rp({
-  url: `${config.apiRoot}/metadata/team`,
-  json: true
-})
-  .then((data) => {
-    module.exports.TEAMS = data;
-  });


### PR DESCRIPTION
Change app.js to explicitly load all the metadata and only start the app if there aren't any errors
Refactor metadata.js to be more DRY and add a new fetchAll method