### PR TITLE
Created a simple filter for now, that refreshes the page when the user checks a box

### DIFF
--- a/app/controller/apicontroller.js
+++ b/app/controller/apicontroller.js
@@ -33,13 +33,6 @@ function companySuggest(req, res) {
     });
 }
 
-function companyDetail(req, res) {
-  companyRepository.getCompany(req.params.sourceId, req.params.source)
-    .then((data) => {
-      res.json(data);
-    });
-}
-
 function countryLookup(req, res) {
 
   if (!req.query.country || req.query.country.length === 0) {
@@ -208,7 +201,6 @@ function teamLookup(req, res) {
 }
 
 router.get('/suggest', companySuggest);
-router.get('/company/:source/:sourceId/?', companyDetail);
 router.get('/countrylookup', countryLookup);
 router.get('/accountmanagerlookup', accountManagerLookup);
 router.get('/contactlookup', contactLookup);
@@ -220,7 +212,6 @@ router.get('/postcodelookup/:postcode', postcodelookup);
 module.exports = {
   postcodelookup,
   companySuggest,
-  companyDetail,
   countryLookup,
   accountManagerLookup,
   contactLookup,

--- a/app/javascripts/companyautocomplete.js
+++ b/app/javascripts/companyautocomplete.js
@@ -69,7 +69,7 @@ class CompanyAutocomplete {
       }
     };
 
-    xmlhttp.open('GET', `/api/company/${company_type}/${id}/`, true);
+    xmlhttp.open('GET', `/company/${company_type}/${id}/json`, true);
     xmlhttp.send();
   }
 

--- a/app/javascripts/facets.js
+++ b/app/javascripts/facets.js
@@ -1,25 +1,18 @@
 import 'babel-polyfill';
-import { addClass, removeClass, toggleClass } from './utils/classtuff';
 import { getQueryParam } from './utils/urlstuff';
 
 const term = getQueryParam('term');
 
 class Facets {
 
-  constructor(targetElement, resultSummaryElement) {
-    this.initElements(targetElement, resultSummaryElement);
+  constructor(targetElement) {
+    this.initElements(targetElement);
     this.addEventHandlers();
-    this.renderFilterList();
+    targetElement.className = '';
   }
 
-  initElements(targetElement, resultSummaryElement) {
+  initElements(targetElement) {
     this.element = targetElement;
-    this.companyCheckbox = this.element.querySelector('input[value="Company"]');
-    this.contactCheckbox = this.element.querySelector('input[value="Contact"]');
-    this.resultSummaryElement = resultSummaryElement;
-    this.nonCategoryFacetElements = Array.prototype.slice.call(this.element.querySelectorAll('.govuk-option-select'));
-    this.nonCategoryFacetElements.splice(0, 1);
-    this.statusFacetsElement = this.nonCategoryFacetElements[1];
     this.clearButtons = this.element.querySelectorAll('.clear-filter-js');
     this.collapseButtons = this.element.querySelectorAll('.collapse-filter-js');
   }
@@ -37,120 +30,16 @@ class Facets {
 
   }
 
-  selectOptionHandler = (event) => {
-    if (event.target.tagName !== 'INPUT') return;
+  selectOptionHandler = () => {
+    let url = `?term=${term}`;
 
-    this.renderFilterList();
-    this.renderSearchSummary();
-  };
-
-  renderFilterList() {
-    removeClass(this.element, 'hidden');
-    const contacts = document.querySelectorAll('.result-list__contact');
-    const companies = document.querySelectorAll('.result-list__ch');
-
-
-    this.hideNoneCategoryFacets();
-
-    if (this.companyCheckbox.checked || this.contactCheckbox.checked) {
-      this.showStatusFacets();
-
-      for (const contact of contacts) {
-        addClass(contact, 'hidden');
-      }
-      for (const company of companies) {
-        addClass(company, 'hidden');
-      }
-
-      if (this.companyCheckbox.checked) {
-        for (const company of companies) {
-          removeClass(company, 'hidden');
-        }
-      }
-
-      if (this.contactCheckbox.checked) {
-        for (const contact of contacts) {
-          removeClass(contact, 'hidden');
-        }
-      }
-    }
-
-    if (!this.companyCheckbox.checked && !this.contactCheckbox.checked) {
-      this.clearStatusOptions();
-
-      for (const contact of contacts) {
-        removeClass(contact, 'hidden');
-      }
-      for (const company of companies) {
-        removeClass(company, 'hidden');
-      }
-    }
-
-    if (this.companyCheckbox.checked) {
-      this.showCompanyFacets();
-    } else {
-      this.clearNoneStatusOptions();
-    }
-
-  }
-
-  clearNoneStatusOptions() {
-    for (var pos = 0; pos < this.nonCategoryFacetElements.length; pos += 1) {
-      if (pos !== 1) {
-        const checkedInputs = this.nonCategoryFacetElements[pos].querySelectorAll('input[type=checkbox]:checked');
-        for (const input of checkedInputs) {
-          input.checked = false;
-        }
-      }
-    }
-  }
-
-  clearStatusOptions() {
-    const checkedInputs = this.statusFacetsElement.querySelectorAll('input[type=checkbox]:checked');
+    const checkedInputs = this.element.querySelectorAll('input[type=checkbox]:checked');
     for (const input of checkedInputs) {
-      input.checked = false;
-    }
-  }
-
-  renderSearchSummary() {
-    let summary;
-
-    if (this.companyCheckbox.checked && !this.contactCheckbox.checked) {
-      summary = `<strong><span class="result-summary--result-count">10</span> company</strong> records found containing <strong>${term}</strong>`;
-    } else if (!this.companyCheckbox.checked && this.contactCheckbox.checked) {
-      summary = `<strong><span class="result-summary--result-count">10</span> contact</strong> records found containing <strong>${term}</strong> `;
-    } else {
-      summary = `<strong><span class="result-summary--result-count">10</span></strong> records found containing <strong>${term}</strong> `;
-    }
-    var subTitle = '';
-
-    var checkedFilters = this.element.querySelectorAll('input[type=checkbox]:checked');
-    for (let filter of checkedFilters) {
-      subTitle += filter.parentElement.innerText + ', ';
+      url += `&${input.name}=${input.value}`;
     }
 
-    if (subTitle.length > 0) {
-      summary += ` which are <strong>${subTitle.substring(0, subTitle.length - 2)}</strong>.`;
-    }
-
-    this.resultSummaryElement.innerHTML = summary;
-  }
-
-  showCompanyFacets() {
-    for (const facetElement of this.nonCategoryFacetElements) {
-      removeClass(facetElement, 'hidden');
-    }
-  }
-
-  showStatusFacets() {
-    removeClass(this.statusFacetsElement, 'hidden');
-  }
-
-  hideNoneCategoryFacets() {
-    for (const facetElement of this.nonCategoryFacetElements) {
-      addClass(facetElement, 'hidden');
-    }
-  }
+    window.location.href = url;
+  };
 
   clearFacetSelection = (event) => {
     const facetWrapper = event.target.parentElement.parentElement.parentElement;
@@ -158,6 +47,7 @@ class Facets {
     for (const input of checkedInputs) {
       input.checked = false;
     }
+    this.selectOptionHandler();
   };
 
   toggleFacet = (event) => {

--- a/app/views/search/facets.html
+++ b/app/views/search/facets.html
@@ -20,7 +20,7 @@
                   {% if option.checked == true %}
                     <input
                       class="facet-option"
-                      name="{{ facet }}"
+                      name="{{ option.name }}"
                       type="checkbox"
                       checked="true"
                       value="{{ option.value }}"
@@ -28,12 +28,12 @@
                   {% else %}
                     <input
                       class="facet-option"
-                      name="{{ facet }}"
+                      name="{{ option.name }}"
                       type="checkbox"
                       value="{{ option.value }}"
                     />
                   {% endif %}
-                  {{ option.value.toLowerCase() }}
+                  {{ option.label }}
                 </label>
               {% endfor %}
             </div>


### PR DESCRIPTION
Refactored some existing filter code based on old API and moved it into the search service.
Modified the code so that a user sends params, the non main search ones are turned into a collection of filters, and filters and valid facets are combined before the page is rendered so that facets indicate which one are active.

Later this may be replaced wth a more SPA way of doing things but it's the simplest for now.

Also note that we currently only allow 1 filter type in the search API but this method was designed to allow more as the API allows, as it is expected that a filter for active/archived will be required real soon now.

Stripped out an unused company api call as it was a duplicate of one in company controller