### PR TITLE
DHE 238 get primary team

### DIFF
--- a/app/controller/companycontroller.js
+++ b/app/controller/companycontroller.js
@@ -96,9 +96,9 @@ function post(req, res) {
   // Flatten selected fields
   let company = Object.assign({}, req.body.company);
 
-  controllerUtils.flattenIdFields(company);
   controllerUtils.flattenAddress(company, 'registered');
   controllerUtils.flattenAddress(company, 'trading');
+  controllerUtils.flattenIdFields(company);
   controllerUtils.nullEmptyFields(company);
 
   if (company.export_to_countries === null) company.export_to_countries = [];

--- a/app/javascripts/components/address.component.js
+++ b/app/javascripts/components/address.component.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import {AutosuggestComponent as Autosuggest} from './autosuggest.component';
 import axios from 'axios';
 
+
 export class AddressComponent extends Component {
 
   constructor(props) {
@@ -40,7 +41,7 @@ export class AddressComponent extends Component {
 
   countryChange = (country) => {
     let address = this.state.address;
-    address.address_country = country.value.id;
+    address.address_country = country.value;
     this.updateAddress(address);
   };
 
@@ -86,22 +87,18 @@ export class AddressComponent extends Component {
     this.setAddressToSuggestion(this.state.addressSuggestions[index]);
   };
 
-  countryForId(countryId) {
-    for (const country of this.state.countryOptions) {
-      if (country.id === countryId) {
-        return country;
-      }
-    }
-    return null;
+
+  hasValidCountry() {
+    return !(!this.state.address || !this.state.address.address_country || !this.state.address.address_country.id ||
+    this.state.address.address_country.id.length === 0);
   }
 
 
   // Rendering
   getMainAddressSection() {
+    if (!this.hasValidCountry()) return null;
+
     const address = this.state.address;
-    if (!address.address_country || address.address_country === null || address.address_country.length === 0) {
-      return null;
-    }
 
     return (
       <div>
@@ -185,19 +182,16 @@ export class AddressComponent extends Component {
   }
 
   getPostcodeLookupSection() {
+    if (!this.hasValidCountry()) return null;
 
-    if (this.state.address.address_country === null || this.state.address.address_country.length === 0) {
-      return null;
-    }
+    const country = this.state.address.address_country;
 
-    const country = this.countryForId(this.state.address.address_country);
-
-    if (country && country.name && country.name === 'United Kingdom') {
+    if (country.name && country.name === 'United Kingdom') {
       const addressSuggestions = this.addressSuggestions();
 
       return (
         <div className="address__lookup-wrapper">
-          <div className="form-group form-group--postcode" id="operatingAddress.postcode-wrapper">
+          <div className="form-group form-group--postcode">
             <label className="form-label">Postcode</label>
             <input
               className="form-control postcode-lookup-value"
@@ -229,7 +223,7 @@ export class AddressComponent extends Component {
       groupClass += ' incomplete';
     }
 
-    const country = this.countryForId(this.state.address.address_country);
+    const country = this.state.address.address_country;
 
     return (
       <fieldset className={groupClass} id={this.props.name + '-wrapper'}>

--- a/app/javascripts/components/autosuggest.component.js
+++ b/app/javascripts/components/autosuggest.component.js
@@ -207,21 +207,31 @@ export class AutosuggestComponent extends Component {
 
   // Navigate suggestions
 
+  setSelected(suggestion) {
+    this.setState({value: suggestion});
+    this.props.onChange({
+      name: this.props.name,
+      value: suggestion
+    });
+    this.clearSuggestions();
+  }
+
   leaveField() {
-    // If the current field value exactly matches the first suggestion
+    // If there is a highlighted field, select it, otherwise
+    // if the current field value exactly matches the first suggestion
     // then select that
     if (this.state.suggestions.length > 0) {
-      const currentValue = this.state.value.name.toLocaleLowerCase();
-      const firstSuggestion = this.state.suggestions[0].name.toLocaleLowerCase();
-
-      if (currentValue === firstSuggestion) {
-        this.setState({value: this.state.suggestions[0]});
-        this.props.onChange({
-          name: this.props.name,
-          value: this.state.suggestions[0]
-        });
-        this.clearSuggestions();
+      if (this.state.highlightedIndex !== null) {
+        this.setSelected(this.state.suggestions[this.state.highlightedIndex]);
         return;
+      } else {
+        const currentValue = this.state.value.name.toLocaleLowerCase();
+        const firstSuggestionName = this.state.suggestions[0].name.toLocaleLowerCase();
+
+        if (currentValue === firstSuggestionName) {
+          this.setSelected(this.state.suggestions[0]);
+          return;
+        }
       }
     }
 

--- a/app/javascripts/forms/companyform.js
+++ b/app/javascripts/forms/companyform.js
@@ -48,7 +48,10 @@ const defaultCompany = {
     address_town: '',
     address_county: '',
     address_postcode: '',
-    address_country: null
+    address_country: {
+      id: null,
+      name: ''
+    }
   },
   alias: '',
   trading_address: {
@@ -57,7 +60,10 @@ const defaultCompany = {
     address_town: '',
     address_county: '',
     address_postcode: '',
-    address_country: null
+    address_country: {
+      id: null,
+      name: ''
+    }
   },
   website: '',
   description: '',

--- a/app/javascripts/forms/contactform.js
+++ b/app/javascripts/forms/contactform.js
@@ -19,7 +19,8 @@ const LABELS = {
   'telephone_alternative': 'Alternative phone (optional)',
   'email_alternative': 'Alternative email (optional)',
   'notes': 'Notes (optional)',
-  'primary': 'Is this person a primary contact?'
+  'primary': 'Is this person a primary contact?',
+  'teams': 'Which team is this person the primary contact for?'
 };
 
 const defaultContact = {
@@ -51,7 +52,11 @@ const defaultContact = {
   },
   telephone_alternative: '',
   email_alternative: '',
-  notes: ''
+  notes: '',
+  teams: [{
+    id: '',
+    name: ''
+  }]
 };
 
 export class ContactForm extends BaseForm {
@@ -98,6 +103,10 @@ export class ContactForm extends BaseForm {
       this.state.formData.address = defaultContact.address;
     }
 
+    if (this.state.primary === false) {
+      this.state.formData.teams = [];
+    }
+
     axios.post('/contact/', { contact: this.state.formData })
       .then((response) => {
         window.location.href = `/contact/${response.data.id}/view`;
@@ -123,6 +132,20 @@ export class ContactForm extends BaseForm {
 
     return '/';
   }
+
+  addPrimaryTeam = (event) => {
+    event.preventDefault();
+    let teams = this.state.formData.teams;
+    teams.push({id: null, name: ''});
+    this.changeFormData('teams', teams);
+  };
+
+  updatePrimaryTeam = (newValue, index) => {
+    let teams = this.state.formData.teams;
+    teams[index] = newValue.value;
+    this.changeFormData('teams', teams);
+  };
+
 
   render() {
 
@@ -209,6 +232,25 @@ export class ContactForm extends BaseForm {
             No
           </label>
         </fieldset>
+        { formData.primary &&
+          <div className="indented-info">
+            {formData.teams.each((team, index) => {
+              return (<Autosuggest
+                name="teams"
+                label={LABELS.teams}
+                value={formData.team}
+                lookupUrl='/api/teamlookup'
+                onChange={(update) => {
+                  this.updatePrimaryTeam(update, index);
+                }}
+                errors={this.getErrors('teams')}
+              />);
+            })}
+            <a className="add-another-button" onClick={this.addPrimaryTeam}>
+              Add another country
+            </a>
+          </div>
+        }
         <InputText
           label={LABELS.telephone_number}
           name="telephone_number"
@@ -247,13 +289,15 @@ export class ContactForm extends BaseForm {
           </label>
         </fieldset>
         { !this.state.formData.address_same_as_company &&
-          <Address
-            name='address'
-            label={LABELS.address}
-            onChange={this.updateField}
-            errors={this.getErrors('address')}
-            value={formData.address}
-          />
+          <div className="indented-info">
+            <Address
+                name='address'
+                label={LABELS.address}
+                onChange={this.updateField}
+                errors={this.getErrors('address')}
+                value={formData.address}
+              />
+          </div>
         }
         <InputText
           label={LABELS.telephone_alternative}

--- a/app/stylesheets/_shame.scss
+++ b/app/stylesheets/_shame.scss
@@ -49,6 +49,15 @@ hr {
   margin: 0 0 30px 0;
 }
 
+.indented-info.error {
+  border-left: 5px solid $error-colour;
+
+  .error {
+    border-left: 0;
+    padding-left: 0;
+  }
+}
+
 .table-detail.table-detail--compact {
   margin-bottom: 0;
 }

--- a/app/views/company/company-details.html
+++ b/app/views/company/company-details.html
@@ -56,7 +56,9 @@
             {% if company.registered_address.address_town.length > 0 %}{{ company.registered_address.address_town }},{% endif %}
             {% if company.registered_address.address_county.length > 0 %}{{ company.registered_address.address_county }},{% endif %}
             {% if company.registered_address.address_postcode.length > 0 %}{{ company.registered_address.address_postcode }},{% endif %}
-            {% if company.registered_address.address_country_name.length > 0 %}{{ company.registered_address.address_country_name }}{% endif %}
+            {% if company.registered_address.address_country and company.registered_address.address_country.name %}
+              {{ company.registered_address.address_country.name }}
+            {% endif %}
           </td>
         </tr>
         <tr>
@@ -82,7 +84,9 @@
             {% if company.trading_address.address_town.length > 0 %}{{ company.trading_address.address_town }},{% endif %}
             {% if company.trading_address.addresss_county.length > 0 %}{{ company.trading_address.address_county }},{% endif %}
             {% if company.trading_address.address_postcode.length > 0 %}{{ company.trading_address.address_postcode }},{% endif %}
-            {% if company.trading_address.address_country_name.length > 0 %}{{ company.trading_address.address_country_name }}{% endif %}
+            {% if company.trading_address.address_country and company.trading_address.address_country.name %}
+              {{ company.trading_address.address_country.name }}
+            {% endif %}
           </td>
         </tr>
         <tr>

--- a/app/views/contact/contact-details.html
+++ b/app/views/contact/contact-details.html
@@ -35,7 +35,13 @@
       <tr>
         <th>Address</th>
         <td>
-          {{ contact.address_1 }}, {% if contact.address_2 %}{{ contact.address_2 }},{% endif %} {{ contact.address_town }}, {{ contact.address_postcode }}
+          {% if not contact.address_same_as_company %}
+            {% if contact.address_1 %}{{ contact.address_2 }},{% endif %}
+            {% if contact.address_2 %}{{ contact.address_2 }},{% endif %}
+            {% if contact.address_town %}{{ contact.address_town }},{% endif %}
+            {% if contact.address_postcode %}{{ contact.address_postcode }}, {% endif %}
+            {% if contact.address.country and contact.address.country.name %}{{ contact.address.country.name }}{% endif %}
+          {% endif %}
         </td>
       </tr>
     {% endif %}

--- a/app/views/contact/contact-edit.html
+++ b/app/views/contact/contact-edit.html
@@ -6,8 +6,7 @@
     var dh = {
       data: {
         contact: {{ contact | dump | safe }},
-        company: {{ company | dump | safe }},
-        lead: {{ lead | dump | safe }}
+        company: {{ company | dump | safe }}
       }
     };
   </script>


### PR DESCRIPTION
After discussion it turns out the teams is a many to many relationship to contacts if they are a primary contact, to indicate to which teams they are a primary for.

The changes also showed up an inconsistency with address country data sent to the client so after discussion this was changed to {id,name} to be consistent with other related. This fixed a bug in which users wouldn't see the country in some view screens and all edit screens. This also allowed code to be deleted from the address component that was a workaround.