### PR TITLE
Dhe 251 - Add CSRF

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "scripts": {
     "clean": "rm -rf build",
-    "start": "node build/server.js",
+    "start": "node --use-strict build/server.js",
     "build": "npm run clean && npm run sass && npm run js",
     "test": "mocha --require test/common.js --ui bdd test/**/*.test.js",
     "lint": "npm run lint:js & npm run lint:sass",

--- a/src/components/selectwithid.component.js
+++ b/src/components/selectwithid.component.js
@@ -92,7 +92,7 @@ class SelectWithIdComponent extends React.Component {
 
 SelectWithIdComponent.propTypes = {
   value: React.PropTypes.string,
-  url: React.PropTypes.string.isRequired,
+  url: React.PropTypes.string,
   name: React.PropTypes.string.isRequired,
   onChange: React.PropTypes.func.isRequired,
   label: React.PropTypes.string.isRequired,

--- a/src/controllers/companycontroller.js
+++ b/src/controllers/companycontroller.js
@@ -1,6 +1,5 @@
 /* eslint new-cap: 0 */
 const express = require('express');
-const router = express.Router();
 const controllerUtils = require('../lib/controllerutils');
 const metadataRepository = require('../repositorys/metadatarepository');
 const companyRepository = require('../repositorys/companyrepository');
@@ -9,13 +8,15 @@ const React = require('react');
 const ReactDom = require('react-dom/server');
 const CompanyForm = require('../forms/companyform');
 
+const router = express.Router();
+
 // Add some extra default info into the company to make it easier to edit
 function postProcessCompany(company) {
   if (!company.export_to_countries || company.export_to_countries.length === 0) {
-    company.export_to_countries = [{id: null, name: ''}];
+    company.export_to_countries = [{ id: null, name: '' }];
   }
   if (!company.future_interest_countries || company.future_interest_countries.length === 0) {
-    company.future_interest_countries = [{id: null, name: ''}];
+    company.future_interest_countries = [{ id: null, name: '' }];
   }
 
   if (company.trading_address && !company.trading_address.address_country) {
@@ -25,7 +26,7 @@ function postProcessCompany(company) {
       address_town: '',
       address_county: '',
       address_postcode: '',
-      address_country: null
+      address_country: null,
     };
   }
 }
@@ -33,8 +34,7 @@ function postProcessCompany(company) {
 function cleanErrors(errors) {
   if (errors.registered_address_1 || errors.registered_address_2 ||
     errors.registered_address_town || errors.registered_address_county ||
-    errors.registered_address_postcode || errors.registered_address_country)
-  {
+    errors.registered_address_postcode || errors.registered_address_country) {
     errors.registered_address = ['Invalid address'];
     delete errors.registered_address_1;
     delete errors.registered_address_2;
@@ -46,8 +46,7 @@ function cleanErrors(errors) {
 
   if (errors.trading_address_1 || errors.trading_address_2 ||
     errors.trading_address_town || errors.trading_address_county ||
-    errors.trading_address_postcode || errors.trading_address_country)
-  {
+    errors.trading_address_postcode || errors.trading_address_country) {
     errors.trading_address = ['Invalid address'];
     delete errors.trading_address_1;
     delete errors.trading_address_2;
@@ -65,15 +64,16 @@ function add(req, res) {
 }
 
 function view(req, res) {
-  let id = req.params.sourceId;
-  let source = req.params.source;
+  const id = req.params.sourceId;
+  const source = req.params.source;
+  const csrfToken = controllerUtils.genCSRF(req);
 
   if (!id) {
     res.redirect('/');
     return;
   }
 
-  companyRepository.getCompany( req.session.token, id, source)
+  companyRepository.getCompany(req.session.token, id, source)
     .then((company) => {
       postProcessCompany(company);
       let formData;
@@ -113,16 +113,16 @@ function view(req, res) {
         timeSinceNewContact,
         timeSinceNewInteraction,
         contactsInLastYear,
-        interactionsInLastYear
+        interactionsInLastYear,
+        csrfToken,
       });
     })
     .catch((error) => {
-      res.render('error', {error});
+      res.render('error', { error });
     });
 }
 
 function post(req, res) {
-
   // Flatten selected fields
   const company = Object.assign({}, req.body.company);
 
@@ -173,7 +173,7 @@ function getJson(req, res) {
       res.json(company);
     })
     .catch((error) => {
-      res.render('error', {error});
+      res.render('error', { error });
     });
 }
 

--- a/src/controllers/interactioncontroller.js
+++ b/src/controllers/interactioncontroller.js
@@ -9,6 +9,7 @@ const router = express.Router();
 
 function view(req, res) {
   const interaction_id = req.params.interaction_id;
+  const csrfToken = controllerUtils.genCSRF(req);
 
   if (!interaction_id) {
     res.redirect('/');
@@ -18,6 +19,7 @@ function view(req, res) {
     .then((interaction) => {
       res.render('interaction/interaction-details', {
         interaction,
+        csrfToken,
       });
     })
     .catch((error) => {
@@ -27,6 +29,7 @@ function view(req, res) {
 
 function edit(req, res) {
   const interactionId = req.params.interaction_id || null;
+  const csrfToken = controllerUtils.genCSRF(req);
 
   interactionRepository.getInteraction(req.session.token, interactionId)
     .then((interaction) => {
@@ -38,6 +41,7 @@ function edit(req, res) {
         company: null,
         contact: null,
         interaction: (interaction || null),
+        csrfToken,
       });
     });
 }
@@ -45,6 +49,7 @@ function edit(req, res) {
 function add(req, res) {
   const companyId = req.query.company_id;
   const contactId = req.query.contact_id;
+  const csrfToken = controllerUtils.genCSRF(req);
 
   if (contactId && contactId.length > 0) {
     contactRepository.getContact(req.session.token, contactId)
@@ -54,6 +59,7 @@ function add(req, res) {
           contact,
           interactionId: null,
           interaction: null,
+          csrfToken,
         });
       });
   } else if (companyId && companyId.length > 0) {
@@ -64,6 +70,7 @@ function add(req, res) {
           contact: null,
           interactionId: null,
           interaction: null,
+          csrfToken,
         });
       });
   } else {
@@ -76,6 +83,7 @@ function post(req, res) {
 
   controllerUtils.flattenIdFields(interaction);
   controllerUtils.nullEmptyFields(interaction);
+  controllerUtils.genCSRF(req, res);
 
   interactionRepository.saveInteraction(req.session.token, interaction)
     .then((data) => {

--- a/src/forms/baseform.js
+++ b/src/forms/baseform.js
@@ -1,8 +1,13 @@
-'use strict';
-
 const React = require('react');
 
 class BaseForm extends React.Component {
+
+  constructor(props) {
+    super(props);
+    if (typeof window !== 'undefined' && window.csrfToken) {
+      this.csrfToken = window.csrfToken;
+    }
+  }
 
   updateField = (update) => {
     let fieldName;

--- a/src/forms/companyform.js
+++ b/src/forms/companyform.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const React = require('react');
 const axios = require('axios');
 const BaseForm = require('./baseform');
@@ -10,7 +8,6 @@ const InputText = require('../components/inputtext.component');
 const ErrorList = require('../components/errorlist.component');
 const DidYouMeanCompany = require('../components/didyoumeancompany.component');
 const Radio = require('../components/radio.component');
-
 
 const LABELS = {
   'name': 'Registered name',
@@ -116,6 +113,9 @@ class CompanyForm extends BaseForm {
       isCDMS: (!company.company_number || company.company_number.length === 0)
     };
 
+    if (typeof window !== 'undefined' && window.csrfToken) {
+      this.csrfToken = window.csrfToken;
+    }
   }
 
   componentDidMount() {
@@ -135,8 +135,6 @@ class CompanyForm extends BaseForm {
     this.allBusinessTypes = types;
     this.ukBusinessTypes = types.filter((businessType) =>
       !(businessType.name.toLowerCase() === 'private limited company' || businessType.name.toLowerCase() === 'public limited company'));
-
-    console.log(this.state.formData.uk_based);
 
     if (this.state.formData.uk_based) {
       this.setState({businessTypes: this.ukBusinessTypes});
@@ -256,11 +254,15 @@ class CompanyForm extends BaseForm {
   save = () => {
     // Just post the company and let the server do the rest. (Get it.. REST)
     this.setState({saving: true});
-    axios.post('/company/', { company: this.state.formData })
+    axios.post('/company/',
+        { company: this.state.formData },
+        { headers: {'X-CSRF-TOKEN': this.csrfToken }}
+      )
       .then((response) => {
         window.location.href = `/company/combined/${response.data.id}`;
       })
       .catch((error) => {
+        console.log(error);
         this.setState({
           errors: error.response.data.errors,
           saving: false
@@ -512,7 +514,8 @@ class CompanyForm extends BaseForm {
   }
 
   static propTypes = {
-    company: React.PropTypes.object
+    company: React.PropTypes.object,
+    csrfToken: React.PropTypes.string
   };
 
 }

--- a/src/forms/companyform.js
+++ b/src/forms/companyform.js
@@ -112,10 +112,6 @@ class CompanyForm extends BaseForm {
       formData: company,
       isCDMS: (!company.company_number || company.company_number.length === 0)
     };
-
-    if (typeof window !== 'undefined' && window.csrfToken) {
-      this.csrfToken = window.csrfToken;
-    }
   }
 
   componentDidMount() {
@@ -256,13 +252,13 @@ class CompanyForm extends BaseForm {
     this.setState({saving: true});
     axios.post('/company/',
         { company: this.state.formData },
-        { headers: {'X-CSRF-TOKEN': this.csrfToken }}
+        { headers: {'x-csrf-token': this.csrfToken }}
       )
       .then((response) => {
         window.location.href = `/company/combined/${response.data.id}`;
       })
       .catch((error) => {
-        console.log(error);
+        this.csrfToken = error.response.headers['x-csrf-token'];
         this.setState({
           errors: error.response.data.errors,
           saving: false

--- a/src/forms/contactform.js
+++ b/src/forms/contactform.js
@@ -106,16 +106,20 @@ class ContactForm extends BaseForm {
 
     this.setState({saving: true});
 
-    axios.post('/contact/', { contact: this.state.formData })
+    axios.post('/contact/',
+      { contact: this.state.formData },
+      { headers: {'x-csrf-token': this.csrfToken }}
+      )
       .then((response) => {
         window.location.href = `/contact/${response.data.id}/view`;
       })
       .catch((error) => {
+        this.csrfToken = error.response.headers['x-csrf-token'];
         this.setState({
           errors: error.response.data.errors,
           saving: false
         });
-      });
+    });
   };
 
   getBackUrl() {

--- a/src/forms/interactionform.js
+++ b/src/forms/interactionform.js
@@ -87,12 +87,15 @@ class InteractionForm extends BaseForm {
   }
 
   save = () => {
-
-    axios.post('/interaction/', { interaction: this.state.formData })
+    axios.post('/interaction/',
+      { interaction: this.state.formData },
+      { headers: {'x-csrf-token': this.csrfToken }}
+      )
       .then((response) => {
         window.location.href = `/interaction/${response.data.id}/view`;
       })
       .catch((error) => {
+        this.csrfToken = error.response.headers['x-csrf-token'];
         this.setState({
           errors: error.response.data.errors,
           saving: false

--- a/src/lib/controllerutils.js
+++ b/src/lib/controllerutils.js
@@ -114,7 +114,7 @@ function genCSRF(req, res) {
   const token = guid();
   req.session.csrfToken = token;
   if (res) {
-    res.set('X-CSRF-TOKEN', token);
+    res.set('x-csrf-token', token);
   }
   return token;
 }

--- a/src/lib/controllerutils.js
+++ b/src/lib/controllerutils.js
@@ -64,7 +64,7 @@ function flattenIdFields(data) {
             ((item && item.id && item.id !== null && item.id.length > 0)
             || (item !== null && item.length > 0)))
           .map(item => item.id);
-      } else if (fieldValue.id) {
+      } else if (typeof fieldValue === 'object' && 'id' in fieldValue) {
         data[fieldName] = fieldValue.id;
       }
     }

--- a/src/lib/controllerutils.js
+++ b/src/lib/controllerutils.js
@@ -1,14 +1,12 @@
-'use strict';
-
 function transformErrors(expressErrors) {
 
   if (!expressErrors) {
     return null;
   }
 
-  let errors = {};
+  const errors = {};
 
-  for (let error of expressErrors) {
+  for (const error of expressErrors) {
     errors[error.param] = error.msg;
   }
 
@@ -16,12 +14,12 @@ function transformErrors(expressErrors) {
 }
 
 function encodeQueryData(data) {
-  var ret = [];
-  for (var key in data) {
-    let item = data[key];
+  const ret = [];
+  for (const key in data) {
+    const item = data[key];
 
     if (Array.isArray(item)) {
-      for (let innerValue of item) {
+      for (const innerValue of item) {
         ret.push(encodeURIComponent(key) + '=' + encodeURIComponent(innerValue));
       }
     } else {
@@ -42,14 +40,13 @@ function convertAutosuggestCollection(form, targetFieldName) {
     if (fieldName.toLocaleLowerCase().substr(0, targetFieldName.length) === lowerTargetFieldName) {
       form[targetFieldName].push({
         id: form[fieldName],
-        name: form[`${fieldName}-display`]
+        name: form[`${fieldName}-display`],
       });
       delete form[`${fieldName}-display`];
       delete form[fieldName];
     }
   }
 }
-
 
 // Scans the properties of an object (forms) and turns data.x = {id:123, name:'y'} into data.x=123
 // This is used so that when a forms posts back an nested object (in the same format it was given the data
@@ -63,22 +60,20 @@ function flattenIdFields(data) {
       if (Array.isArray(fieldValue)) {
         // Scan through the array of values, strip out any that are null, empty or have a null or empty id
         data[fieldName] = fieldValue
-          .filter((item) =>
-            (item && item.hasOwnProperty('id') && item.id !== null && item.id.length > 0
-            || item !== null && item.length > 0))
-          .map((item) => item.id);
-      } else if (fieldValue.hasOwnProperty('id')) {
+          .filter(item =>
+            ((item && item.id && item.id !== null && item.id.length > 0)
+            || (item !== null && item.length > 0)))
+          .map(item => item.id);
+      } else if (fieldValue.id) {
         data[fieldName] = fieldValue.id;
       }
     }
   }
 }
 
-
 function flattenAddress(data, addressName) {
 
   if (addressName) {
-
     if (data[`${addressName}_address`]) {
       const address = data[`${addressName}_address`];
       const addressKeys = Object.keys(address);
@@ -105,11 +100,31 @@ function nullEmptyFields(data) {
   }
 }
 
+function guid() {
+  function s4() {
+    return Math.floor((1 + Math.random()) * 0x10000)
+      .toString(16)
+      .substring(1);
+  }
+  return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
+    s4() + '-' + s4() + s4() + s4();
+}
+
+function genCSRF(req, res) {
+  const token = guid();
+  req.session.csrfToken = token;
+  if (res) {
+    res.set('X-CSRF-TOKEN', token);
+  }
+  return token;
+}
+
 module.exports = {
   transformErrors,
   encodeQueryData,
   convertAutosuggestCollection,
   flattenIdFields,
   flattenAddress,
-  nullEmptyFields
+  nullEmptyFields,
+  genCSRF,
 };

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,12 +1,8 @@
-'use strict';
-
 module.exports = function auth(req, res, next) {
-
   if (req.url !== '/login' && req.url !== '/error' && !req.session.token) {
     res.redirect('/login');
     return;
   }
 
   next();
-
 };

--- a/src/middleware/csrf.js
+++ b/src/middleware/csrf.js
@@ -4,10 +4,17 @@ module.exports = (req, res, next) => {
   }
 
   try {
-    const requestCsrf = req.get('X-CSRF-TOKEN');
     const sessionCsrf = req.session.csrfToken;
+    let requestCsrf;
 
-    // Not matter what, reset the token.
+    // Look for the csrf token first in the form body, if not then the http headers
+    if (req.body && req.body._csrf_token) {
+      requestCsrf = req.body._csrf_token;
+    } else {
+      requestCsrf = req.get('x-csrf-token');
+    }
+
+    // Not matter what, reset the token now it has been used.
     req.session.csrfToken = null;
 
     if (!requestCsrf || !sessionCsrf || requestCsrf !== sessionCsrf) {

--- a/src/middleware/csrf.js
+++ b/src/middleware/csrf.js
@@ -1,0 +1,21 @@
+module.exports = (req, res, next) => {
+  if (req.method !== 'POST' || req.url === '/login') {
+    return next();
+  }
+
+  try {
+    const requestCsrf = req.get('X-CSRF-TOKEN');
+    const sessionCsrf = req.session.csrfToken;
+
+    // Not matter what, reset the token.
+    req.session.csrfToken = null;
+
+    if (!requestCsrf || !sessionCsrf || requestCsrf !== sessionCsrf) {
+      throw true;
+    }
+  } catch (e) {
+    return res.sendStatus(400);
+  }
+
+  return next();
+};

--- a/src/middleware/flash.js
+++ b/src/middleware/flash.js
@@ -1,0 +1,14 @@
+module.exports = (req, res, next) => {
+  const formErrors = req.flash('error');
+
+  res.locals.messages = {
+    success: req.flash('success-message'),
+    error: req.flash('error-message'),
+  };
+
+  if (formErrors && formErrors.length) {
+    res.locals.messages.formErrors = formErrors;
+  }
+
+  next();
+};

--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const config = require( '../config' );
 const authorisedRequest = require( '../lib/authorisedrequest' );
 

--- a/src/pages/company.js
+++ b/src/pages/company.js
@@ -1,11 +1,11 @@
-/* globals interactions: true, company: true, contacts: true */
+/* globals interactions: true, company: true, contacts: true, document: true */
 
 require('babel-polyfill');
 const React = require('react');
 const ReactDOM = require('react-dom');
 
 const CompanyForm = require('../forms/companyform');
-const ContactTable = require( '../components/contacttable.component');
+const ContactTable = require('../components/contacttable.component');
 const InteractionTable = require('../components/interactiontable.component');
 const { addClass, removeClass } = require('../lib/elementstuff');
 const Edit = require('../controls/edit');
@@ -22,17 +22,17 @@ const archiveReasonGroup = document.getElementById('archived_reason-wrapper');
 
 
 if (contacts && contacts.length > 0) {
-  const validContacts = contacts.filter((contact) => !contact.archived);
-  const archivedContacts = contacts.filter((contact) => contact.archived);
+  const validContacts = contacts.filter(contact => !contact.archived);
+  const archivedContacts = contacts.filter(contact => contact.archived);
 
   ReactDOM.render(
-    <ContactTable contacts={validContacts}/>,
-    document.querySelector('#contact-table-wrapper')
+    <ContactTable contacts={validContacts} />,
+    document.querySelector('#contact-table-wrapper'),
   );
 
   ReactDOM.render(
     <ContactTable contacts={archivedContacts} archived />,
-    document.querySelector('#archived-contact-table-wrapper')
+    document.querySelector('#archived-contact-table-wrapper'),
   );
 
   if (archivedContacts.length === 0) {
@@ -41,7 +41,6 @@ if (contacts && contacts.length > 0) {
   if (validContacts.length === 0) {
     addClass(document.getElementById('contact-table-wrapper'), 'hidden');
   }
-
 } else {
   const section = document.getElementById('archived-section');
   if (section) {
@@ -51,8 +50,8 @@ if (contacts && contacts.length > 0) {
 
 if (interactions && interactions.length > 0) {
   ReactDOM.render(
-    <InteractionTable interactions={interactions}/>,
-    document.querySelector('#interaction-table-wrapper')
+    <InteractionTable interactions={interactions} />,
+    document.querySelector('#interaction-table-wrapper'),
   );
 }
 
@@ -74,7 +73,7 @@ function showArchiveError() {
 }
 
 function submitArchiveForm(event) {
-  let reason = archiveReasonElement.options[archiveReasonElement.selectedIndex].value;
+  const reason = archiveReasonElement.options[archiveReasonElement.selectedIndex].value;
   if (!reason) {
     event.preventDefault();
     showArchiveError();
@@ -88,4 +87,4 @@ if (archiveButton) {
 }
 
 
-ReactDOM.render(<CompanyForm company={company}/>, document.getElementById('company-edit'));
+ReactDOM.render(<CompanyForm company={company} />, document.getElementById('company-edit'));

--- a/src/pages/contactedit.js
+++ b/src/pages/contactedit.js
@@ -1,8 +1,6 @@
-/* global dh:true */
-'use strict';
-
-
+/* global dh:true, document: true */
 require('babel-polyfill');
+
 const React = require('react');
 const ReactDOM = require('react-dom');
 const ContactForm = require('../forms/contactform');
@@ -11,8 +9,9 @@ const editElement = document.getElementById('contact-form');
 const contact = dh.data.contact;
 const company = dh.data.company;
 const lead = dh.data.lead;
-let backUrl, backTitle, title;
-
+let backUrl;
+let backTitle;
+let title;
 
 if (company) {
   backUrl = `/company/company_company/${company.id}#contacts`;
@@ -33,7 +32,7 @@ ReactDOM.render(
   <div>
     <a className="back-link" href={backUrl}>Back to {backTitle}</a>
     <h1 className="heading-xlarge">{ title }</h1>
-    <ContactForm contact={contact} company={company} lead={lead}/>
+    <ContactForm contact={contact} company={company} lead={lead} />
   </div>,
-  editElement
+  editElement,
 );

--- a/src/views/company/company-add.html
+++ b/src/views/company/company-add.html
@@ -10,6 +10,6 @@
 </div>
 <script src="/javascripts/react/react.min.js"></script>
 <script src="/javascripts/react-dom/react-dom.min.js"></script>
-<script>window.csrfToken='{{csrfToken}}';</script>
+<script>window.csrfToken={{ csrfToken | stringify }};</script>
 <script src="/javascripts/companyadd.bundle.js"></script>
 {% endblock %}

--- a/src/views/company/company-add.html
+++ b/src/views/company/company-add.html
@@ -10,5 +10,6 @@
 </div>
 <script src="/javascripts/react/react.min.js"></script>
 <script src="/javascripts/react-dom/react-dom.min.js"></script>
+<script>window.csrfToken='{{csrfToken}}';</script>
 <script src="/javascripts/companyadd.bundle.js"></script>
 {% endblock %}

--- a/src/views/company/company-add.html
+++ b/src/views/company/company-add.html
@@ -10,6 +10,6 @@
 </div>
 <script src="/javascripts/react/react.min.js"></script>
 <script src="/javascripts/react-dom/react-dom.min.js"></script>
-<script>window.csrfToken={{ csrfToken | stringify }};</script>
+<script>window.csrfToken='{{ csrfToken }}';</script>
 <script src="/javascripts/companyadd.bundle.js"></script>
 {% endblock %}

--- a/src/views/company/company.html
+++ b/src/views/company/company.html
@@ -20,6 +20,7 @@
   {% if company.id %}
     {% if not company.archived %}
       <form id="archive-details" class="hidden" action="/company/{{ company.id }}/archive" method="post">
+        <input type="hidden" name="_csrf_token" value="{{csrfToken}}"/>
         {{ forms.dropdown('archived_reason',
           label="Reason for archiving company",
           emptyLabel="Select a value",
@@ -130,7 +131,7 @@
     var company = {{ company | stringify | safe }};
     var contacts = {{ company.contacts | stringify | safe }};
     var interactions = {{ company.interactions | stringify | safe }};
-    window.csrfToken={{ csrfToken | stringify }};
+    window.csrfToken='{{ csrfToken }}';
   </script>
   <script src="/javascripts/react/react.min.js"></script>
   <script src="/javascripts/react-dom/react-dom.min.js"></script>

--- a/src/views/company/company.html
+++ b/src/views/company/company.html
@@ -129,7 +129,8 @@
   <script>
     var company = {{ company | stringify | safe }};
     var contacts = {{ company.contacts | stringify | safe }};
-    var interactions = {{ company.interactions |stringify | safe }};
+    var interactions = {{ company.interactions | stringify | safe }};
+    window.csrfToken={{ csrfToken | stringify }};
   </script>
   <script src="/javascripts/react/react.min.js"></script>
   <script src="/javascripts/react-dom/react-dom.min.js"></script>

--- a/src/views/contact/contact-edit.html
+++ b/src/views/contact/contact-edit.html
@@ -6,9 +6,10 @@
     var dh = {
       data: {
         contact: {{ contact | dump | safe }},
-        company: {{ company | dump | safe }}
-      }
+        company: {{ company | dump | safe }},
+      },
     };
+    window.csrfToken='{{ csrfToken }}';
   </script>
   <script src="/javascripts/react/react.min.js"></script>
   <script src="/javascripts/react-dom/react-dom.min.js"></script>

--- a/src/views/contact/contact.html
+++ b/src/views/contact/contact.html
@@ -19,6 +19,7 @@
 
   {% if not contact.archived %}
     <form id="archive-details" class="hidden" action="/contact/{{ contact.id }}/archive" method="post">
+      <input type="hidden" name="_csrf_token" value="{{csrfToken}}"/>
       {{ forms.dropdown('archived_reason',
       label="Reason for archiving contact",
       emptyLabel="Select a value",

--- a/src/views/interaction/interaction-edit.html
+++ b/src/views/interaction/interaction-edit.html
@@ -8,8 +8,9 @@
         contact: {{ contact | dump | safe }},
         company: {{ company | dump | safe }},
         interaction: {{ interaction | dump | safe }}
-      }
+      },
     };
+    window.csrfToken='{{ csrfToken }}';
   </script>
   <script src="/javascripts/react/react.min.js"></script>
   <script src="/javascripts/react-dom/react-dom.min.js"></script>


### PR DESCRIPTION
Add CSRF to all forms and parts of the application that update data.

The out of the box CSRF solutions all seem to revolve around csrf in regular html forms, and don't provide easy csrf support for ajax.

This solution is very simple and lightweight:
* For all requests to pages that carry out an action a csrf token is generated and placed in the users session and sent to the page to be rendered.
* All post requests to the system are intercepted and the csrf token is checked for and compared to the csrf token in the users session then cleared.
* Regular forms include the csrf token as a hidden field
* React forms look for the csrf token in the global namespace then send that as a http header when they save data.
* If a form post raises an error that is sent back in the response in a http header and used to replace the current token the react form has so it will use the new token for the next save action.
