### PR TITLE
Fixed highlight function to fix issue when term contained a *

### DIFF
--- a/src/lib/nunjuckfilters.js
+++ b/src/lib/nunjuckfilters.js
@@ -125,13 +125,22 @@ filter.humanFieldName = function(fieldName) {
   return fieldName;
 };
 
-filter.highlightTerm = function(phrase, term) {
-  if (!phrase || phrase.length === 0) {
-    return '';
-  }
-  var regex = new RegExp('(' + term + ')', 'gi');
-  return '<span>' + phrase.replace(regex, '<strong>$1</strong>') + '</span>';
+function escapeRegExp(str) {
+  if (str || str.length === 0) return str;
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
 
+filter.highlightTerm = function highlightTerm(phrase, term = '') {
+  try {
+    if (!phrase) phrase = '';
+    if (phrase.length === 0 || term.length === 0) return phrase;
+
+    const cleanTerm = term.replace(/\*/g, '').replace(/\\/g, '\\\\');
+    const regex = new RegExp(escapeRegExp(`(${cleanTerm})`), 'gi');
+    return phrase.replace(regex, '<strong>$1</strong>');
+  } catch (e) {
+    return phrase;
+  }
 };
 
 

--- a/test/lib/nunjuckfilters.test.js
+++ b/test/lib/nunjuckfilters.test.js
@@ -1,0 +1,47 @@
+/* globals expect: true, describe: true, it: true */
+'use strict';
+
+const nunjuckfilters = require('../../src/lib/nunjuckfilters');
+
+describe('Filters', () => {
+  describe('Highlight term', () => {
+    it('Should highlight a simple term in a phrase', () => {
+      const result = nunjuckfilters.highlightTerm('White rabbit, red strawberry', 'rabbit');
+      expect(result).to.equal('White <strong>rabbit</strong>, red strawberry');
+    });
+    it('Should ignore case when highlighting but preserve original phrase case', () => {
+      const resultA = nunjuckfilters.highlightTerm('White rabbit, red strawberry', 'Rabbit');
+      expect(resultA).to.equal('White <strong>rabbit</strong>, red strawberry');
+      const resultB = nunjuckfilters.highlightTerm('White Rabbit, red strawberry', 'rabbit');
+      expect(resultB).to.equal('White <strong>Rabbit</strong>, red strawberry');
+    });
+    it('Should highlight a term with * in it', () => {
+      const result = nunjuckfilters.highlightTerm('White rabbit, red strawberry', '*rabbit');
+      expect(result).to.equal('White <strong>rabbit</strong>, red strawberry');
+    });
+    it('Should highlight a term with \\ in it', () => {
+      const result = nunjuckfilters.highlightTerm('White \\rabbit, red strawberry', '\\rabbit');
+      expect(result).to.equal('White <strong>\\rabbit</strong>, red strawberry');
+    });
+    it('Should highlight a term with a special character in it', () => {
+      const result = nunjuckfilters.highlightTerm("Est-ce que vous pouvez l'écrire", "l'écrire");
+      expect(result).to.equal("Est-ce que vous pouvez <strong>l'écrire</strong>");
+    });
+    it('Should work fine if sent an empty term', () => {
+      const result = nunjuckfilters.highlightTerm('White rabbit, red strawberry', '');
+      expect(result).to.equal('White rabbit, red strawberry');
+    });
+    it('Should work fine if sent an empty phrase', () => {
+      const result = nunjuckfilters.highlightTerm('', 'Strawberry');
+      expect(result).to.equal('');
+    });
+    it('should handle null term', () => {
+      const result = nunjuckfilters.highlightTerm('White rabbit, red strawberry');
+      expect(result).to.equal('White rabbit, red strawberry');
+    });
+    it('should handle null phrase', () => {
+      const result = nunjuckfilters.highlightTerm(null, 'Strawberry');
+      expect(result).to.equal('');
+    });
+  });
+});


### PR DESCRIPTION
When a term contains a * the resulting regex is invalid. Updated function to not only handle * and \ but added tests to confirm the fix and also handle none uk company names.