### PR TITLE
Handle 500's from API Server

### DIFF
--- a/src/components/errorlist.component.js
+++ b/src/components/errorlist.component.js
@@ -27,6 +27,12 @@ function errorListComponent(props) {
     const error = Array.isArray(props.errors[fieldName]) ? props.errors[fieldName][0] : props.errors[fieldName];
     const label = props.labels[fieldName] || fieldName;
 
+    if (label === 'detail') {
+      return (
+        <li key={fieldName}>{error}</li>
+      );
+    }
+
     return (
       <li key={fieldName}>
         <a href={`#${fieldName}-wrapper`}>{label} - {error}</a>
@@ -37,7 +43,7 @@ function errorListComponent(props) {
   return (
     <div className="error-summary" role="group" tabIndex="-1">
       <h1 className="heading-medium error-summary-heading" id="error-summary-heading">
-        Incomplete Information
+        Errors
       </h1>
       <ul className="error-summary-list">{errorListMarkup}</ul>
     </div>

--- a/src/controllers/companycontroller.js
+++ b/src/controllers/companycontroller.js
@@ -70,7 +70,7 @@ function get(req, res) {
     })
     .catch((error) => {
       const errors = error.error;
-      return res.status(400).json({ errors });
+      return res.status(error.response.statusCode).json({ errors });
     });
 }
 
@@ -91,11 +91,11 @@ function post(req, res) {
     })
     .catch((error) => {
       if (typeof error.error === 'string') {
-        return res.status(error.response.statusCode).json({ errors: [{ error: error.response.statusMessage }] });
+        return res.status(error.response.statusCode).json({ errors: { detail: error.response.statusMessage } });
       }
       const errors = error.error;
       cleanErrors(errors);
-      return res.status(400).json({ errors });
+      return res.status(error.response.statusCode).json({ errors });
     });
 }
 
@@ -109,11 +109,11 @@ function archive(req, res) {
     .catch((error) => {
       winston.log('error', error);
       if (typeof error.error === 'string') {
-        return res.status(error.response.statusCode).json({ errors: [{ error: error.response.statusMessage }] });
+        return res.status(error.response.statusCode).json({ errors: { detail: error.response.statusMessage } });
       }
       const errors = error.error;
       cleanErrors(errors);
-      return res.status(400).json({ errors });
+      return res.status(error.response.statusCode).json({ errors });
     });
 }
 
@@ -127,11 +127,11 @@ function unarchive(req, res) {
     .catch((error) => {
       winston.error('error', error);
       if (typeof error.error === 'string') {
-        return res.status(error.response.statusCode).json({ errors: [{ error: error.response.statusMessage }] });
+        return res.status(error.response.statusCode).json({ errors: { detail: error.response.statusMessage } });
       }
       const errors = error.error;
       cleanErrors(errors);
-      return res.status(400).json({ errors });
+      return res.status(error.response.statusCode).json({ errors });
     });
 }
 

--- a/src/controllers/contactcontroller.js
+++ b/src/controllers/contactcontroller.js
@@ -81,13 +81,13 @@ function post(req, res) {
     })
     .catch((error) => {
       if (typeof error.error === 'string') {
-        return res.status(error.response.statusCode).json({ errors: [{ error: error.response.statusMessage }] });
+        return res.status(error.response.statusCode).json({ errors: { detail: error.response.statusMessage } });
       }
 
       const errors = error.error;
       cleanErrors(errors);
 
-      return res.status(400).json({ errors });
+      return res.status(error.response.statusCode).json({ errors });
     });
 }
 
@@ -101,11 +101,11 @@ function archive(req, res) {
     .catch((error) => {
       winston.log('error', error);
       if (typeof error.error === 'string') {
-        return res.status(error.response.statusCode).json({ errors: [{ error: error.response.statusMessage }] });
+        return res.status(error.response.statusCode).json({ errors: { detail: error.response.statusMessage } });
       }
       const errors = error.error;
       cleanErrors(errors);
-      return res.status(400).json({ errors });
+      return res.status(error.response.statusCode).json({ errors });
     });
 }
 
@@ -119,11 +119,11 @@ function unarchive(req, res) {
     .catch((error) => {
       winston.error('error', error);
       if (typeof error.error === 'string') {
-        return res.status(error.response.statusCode).json({ errors: [{ error: error.response.statusMessage }] });
+        return res.status(error.response.statusCode).json({ errors: { detail: error.response.statusMessage } });
       }
       const errors = error.error;
       cleanErrors(errors);
-      return res.status(400).json({ errors });
+      return res.status(error.response.statusCode).json({ errors });
     });
 }
 

--- a/src/controllers/interactioncontroller.js
+++ b/src/controllers/interactioncontroller.js
@@ -46,7 +46,7 @@ function get(req, res) {
     })
     .catch((error) => {
       const errors = error.error;
-      return res.status(400).json({ errors });
+      return res.status(error.response.statusCode).json({ errors });
     });
 }
 
@@ -63,11 +63,11 @@ function post(req, res) {
     })
     .catch((error) => {
       if (typeof error.error === 'string') {
-        return res.status(error.response.statusCode).json({ errors: [{ error: error.response.statusMessage }] });
+        return res.status(error.response.statusCode).json({ errors: { detail: error.response.statusMessage } });
       }
 
       const errors = error.error;
-      return res.status(400).json({ errors });
+      return res.status(error.response.statusCode).json({ errors });
     });
 }
 


### PR DESCRIPTION
Handle Leeloo returning 500 errors with structured error responses and use ‘detail’ as a reserved field name for none form errors. Include original error response code too, to make it slightly easier to spot difference between 400 and 500.

Will create a follow up card to this to create unit tests for each layer in the service