### PR TITLE
Refactor handling of saving companies to the repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "morgan": "1.7.0",
     "node-sass": "^4.0.0",
     "nunjucks": "^3.0.0",
+    "proxyquire": "^1.7.10",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "react-highlighter": "^0.3.3",

--- a/src/controllers/companycontroller.js
+++ b/src/controllers/companycontroller.js
@@ -89,13 +89,9 @@ function post(req, res) {
     .then((data) => {
       res.json(data);
     })
-    .catch((error) => {
-      if (typeof error.error === 'string') {
-        return res.status(error.response.statusCode).json({ errors: { detail: error.response.statusMessage } });
-      }
-      const errors = error.error;
+    .catch(({ statusCode, errors }) => {
       cleanErrors(errors);
-      return res.status(error.response.statusCode).json({ errors });
+      return res.status(statusCode).json({ errors });
     });
 }
 

--- a/test/repositorys/companyrepository.test.js
+++ b/test/repositorys/companyrepository.test.js
@@ -1,0 +1,251 @@
+/* globals expect: true, describe: true, it: true, beforeEach: true */
+const proxyquire = require('proxyquire');
+
+describe('Company repository', () => {
+
+  describe('Save company', () => {
+    describe('Handle response from server', () => {
+      describe('Successfully save a company', () => {
+        let companyRepository;
+        const authorisedRequestStub = function() {
+          return new Promise((success) => {
+            success({
+              id: '1234',
+              name: 'fred'
+            });
+          });
+        };
+
+        beforeEach(() => {
+          companyRepository = makeRepositoryWithAuthRequest(authorisedRequestStub);
+        });
+        it('should return data if successful', (done) => {
+          companyRepository.saveCompany('1234', {id: '1234', name: 'fred'})
+            .then((data) => {
+              expect(data.id).to.equal('1234');
+              done();
+            })
+            .catch(() => {
+              fail();
+            });
+        });
+      });
+      describe('Save a company and get a 400', () => {
+        let companyRepository;
+        const authorisedRequestStub = function() {
+          return new Promise((success, failure) => {
+            failure({
+              error: {
+                sector: ['error with sector'],
+              },
+              message: '400 - {"sector":["error with sector"]}',
+              name: 'StatusCodeError',
+              response: {
+                statusCode: 400,
+                statusMessage: 'Bad Request',
+              },
+            });
+          });
+        };
+
+        beforeEach(() => {
+          companyRepository = makeRepositoryWithAuthRequest(authorisedRequestStub);
+        });
+        it('should return an error and a formatted error response', (done) => {
+          companyRepository.saveCompany('1234', {id: '1234', name: 'fred'})
+            .then(() => {
+              fail();
+            })
+            .catch((error) => {
+              expect(error).to.have.property('statusCode');
+              expect(error).to.have.property('errors');
+              done();
+            });
+        });
+        it('should indicate the error code', (done) => {
+          companyRepository.saveCompany('1234', {id: '1234', name: 'fred'})
+            .then(() => {
+              fail();
+            })
+            .catch((error) => {
+              expect(error.statusCode).to.equal(400);
+              done();
+            });
+        });
+        it('should show that there was an error with a field', (done) => {
+          companyRepository.saveCompany('1234', {id: '1234', name: 'fred'})
+            .then(() => {
+              fail();
+            })
+            .catch((error) => {
+              expect(error.errors).to.eql({
+                sector: ['error with sector']
+              });
+              done();
+            });
+        });
+      });
+      describe('Save a company and get a formatted 500', () => {
+        let companyRepository;
+        const authorisedRequestStub = function() {
+          return new Promise((success, failure) => {
+            failure({
+              error: {'detail': 'Service Unavailable'},
+              name: "StatusCodeError",
+              response: {
+                statusCode: 501
+              }
+            });
+          });
+        };
+
+        beforeEach(() => {
+          companyRepository = makeRepositoryWithAuthRequest(authorisedRequestStub);
+        });
+        it('should return an error and a formatted error response', (done) => {
+          companyRepository.saveCompany('1234', {id: '1234', name: 'fred'})
+            .then(() => {
+              fail();
+            })
+            .catch((error) => {
+              expect(error).to.have.property('statusCode');
+              expect(error).to.have.property('errors');
+              done();
+            });
+        });
+        it('should indicate the error code', (done) => {
+          companyRepository.saveCompany('1234', {id: '1234', name: 'fred'})
+            .then(() => {
+              fail();
+            })
+            .catch((error) => {
+              expect(error.statusCode).to.equal(501);
+              expect(error.errors).to.eql({ detail: 'Service Unavailable' });
+              done();
+            });
+        });
+      });
+      describe('Save a company and get a generic 500', () => {
+        let companyRepository;
+        const authorisedRequestStub = function() {
+          return new Promise((success, failure) => {
+            failure({
+              error: 'Service Unavailable\n',
+              message: '503 "Service Unavailable\"',
+              name: "StatusCodeError",
+              response: {
+                statusCode: 501,
+                statusMessage: 'Service Unavailable'
+              }
+            });
+          });
+        };
+
+        beforeEach(() => {
+          companyRepository = makeRepositoryWithAuthRequest(authorisedRequestStub);
+        });
+        it('should return an error and a formatted error response', (done) => {
+          companyRepository.saveCompany('1234', {id: '1234', name: 'fred'})
+            .then(() => {
+              fail();
+            })
+            .catch((error) => {
+              expect(error).to.have.property('statusCode');
+              expect(error).to.have.property('errors');
+              done();
+            });
+        });
+        it('should indicate the error code', (done) => {
+          companyRepository.saveCompany('1234', {id: '1234', name: 'fred'})
+            .then(() => {
+              fail();
+            })
+            .catch((error) => {
+              expect(error.statusCode).to.equal(501);
+              expect(error.errors).to.eql({ detail: 'Service Unavailable' });
+              done();
+            });
+        });
+      });
+    });
+    describe('Make correct call to API', () => {
+      it('should call the API with a PUT if an ID is provided.', (done) => {
+        const authorisedRequestStub = function(token, opts) {
+          expect(opts.method).to.eq('PUT');
+          return new Promise((success) => {
+            success({ id: '1234', name: 'fred' });
+          });
+        };
+        const companyRepository = makeRepositoryWithAuthRequest(authorisedRequestStub);
+
+        companyRepository.saveCompany('1234', { id: '1234', name: 'fred' })
+          .then(() => {
+            done();
+          })
+          .catch((error) => {
+            throw Error(error);
+          });
+      });
+      it('should call the API at /company/id/ if an ID is provided', (done) => {
+        const authorisedRequestStub = function(token, opts) {
+          expect(opts.url).to.eq('http://localhost:8000/company/1234/');
+          return new Promise((success) => {
+            success({ id: '1234', name: 'fred' });
+          });
+        };
+        const companyRepository = makeRepositoryWithAuthRequest(authorisedRequestStub);
+
+        companyRepository.saveCompany('1234', { id: '1234', name: 'fred' })
+          .then(() => {
+            done();
+          })
+          .catch((error) => {
+            throw Error(error);
+          });
+      });
+      it('should call the API with a POST if no ID is provided.', (done) => {
+        const authorisedRequestStub = function(token, opts) {
+          expect(opts.method).to.eq('POST');
+          return new Promise((success) => {
+            success({ id: '1234', name: 'fred' });
+          });
+        };
+        const companyRepository = makeRepositoryWithAuthRequest(authorisedRequestStub);
+
+        companyRepository.saveCompany('1234', { name: 'fred' })
+          .then(() => {
+            done();
+          })
+          .catch((error) => {
+            throw Error(error);
+          });
+      });
+      it('should call the API at /company/ if no ID is provided', (done) => {
+        const authorisedRequestStub = function(token, opts) {
+          expect(opts.url).to.eq('http://localhost:8000/company/');
+          return new Promise((success) => {
+            success({ id: '1234', name: 'fred' });
+          });
+        };
+        const companyRepository = makeRepositoryWithAuthRequest(authorisedRequestStub);
+
+        companyRepository.saveCompany('1234', { name: 'fred' })
+          .then(() => {
+            done();
+          })
+          .catch((error) => {
+            throw Error(error);
+          });
+      });
+    });
+  });
+
+  function makeRepositoryWithAuthRequest(authorisedRequestStub) {
+    return proxyquire('../../src/repositorys/companyrepository', {'../lib/authorisedrequest': authorisedRequestStub});
+  }
+
+  function fail() {
+    expect(true).to.eq(false);
+  }
+
+});


### PR DESCRIPTION
The previous card to handle errors when saving was hard to do because there was no test coverage.

Refactored the repository to make it fully responsible for saving and handling errors, instead of splitting it between the controller and made it easier to test error handling.

Introduced unit tests for company repository to quickly test handling good and bad saves, and simulate failures in load balancers and web servers a well as structured errors from the API.