### PR TITLE
Fix an error when the user saves a form with no sector

### DIFF
--- a/src/components/sectorselect.component.js
+++ b/src/components/sectorselect.component.js
@@ -20,14 +20,14 @@ class SectorSelect extends React.Component {
     super(props);
 
     const allSectors = this.props.allSectors;
-    const sector = this.props.sector;
+    const sector = this.props.sector || { id: '', name: '' };
     const primarySector = transformSectors.getPrimarySectorName(sector.name) || '';
 
     this.allPrimarySectors = transformSectors.getAllPrimarySectors(allSectors);
 
     this.state = {
       primarySector,
-      value: this.props.sector.id,
+      value: sector.id,
       errors: this.props.errors,
       subSectors: transformSectors.getAllSubSectors(primarySector, allSectors) || [],
     };


### PR DESCRIPTION
The sector select control couldn't handle a situation where no sector was provided, changed this to provide a default if no sector is provided.