### PR TITLE
Prefetch the types of interaction, this is data that rarely changes

### DIFF
--- a/src/controllers/apicontroller.js
+++ b/src/controllers/apicontroller.js
@@ -72,10 +72,7 @@ function getMetadata(req, res) {
       result = metadataRepository.TYPES_OF_BUSINESS;
       break;
     case 'typesofinteraction':
-      authorisedRequest(req.session.token, `${config.apiRoot}/metadata/interaction-type/`)
-        .then((response) => {
-          res.json(response);
-        });
+      result = metadataRepository.TYPES_OF_INTERACTION;
       return;
     case 'sector':
       result = metadataRepository.SECTOR_OPTIONS;

--- a/src/repositorys/metadatarepository.js
+++ b/src/repositorys/metadatarepository.js
@@ -51,6 +51,7 @@ const metadataItems = [
   ['employee-range', 'EMPLOYEE_OPTIONS'],
   ['business-type', 'TYPES_OF_BUSINESS'],
   ['team', 'TEAMS'],
+  ['interaction-type', 'TYPES_OF_INTERACTION'],
 ];
 
 module.exports.setRedisClient = (client) => {


### PR DESCRIPTION
- Remove calls to lookup all related contacts to a company, we have all the data needed now that job title is no longer used.
- Remove calls to lookup interaction data and its related contacts, instead use locally cached data for type, get the contact data from the contacts already in the company response and only fetch the advisors we need to.