### PR TITLE
When loading a company or contact, show when the record is not found.

### DIFF
--- a/src/apps/company.app.js
+++ b/src/apps/company.app.js
@@ -18,7 +18,11 @@ class CompanyApp extends React.Component {
         cb(null, { company, source: params.source, sourceId: params.sourceId, backLink });
       })
       .catch((error) => {
-        cb(error);
+        if (error.error && error.error.detail) {
+          cb(error.error.detail);
+        } else {
+          cb('Error loading company')
+        }
       });
   }
 

--- a/src/apps/contact.app.js
+++ b/src/apps/contact.app.js
@@ -22,7 +22,11 @@ class ContactApp extends React.Component {
         cb(null, { contact, contactId: params.contactId, backLink });
       })
       .catch((error) => {
-        cb(error);
+        if (error.error && error.error.detail) {
+          cb(error.error.detail);
+        } else {
+          cb('Error loading contact')
+        }
       });
   }
 

--- a/src/controllers/companycontroller.js
+++ b/src/controllers/companycontroller.js
@@ -51,8 +51,12 @@ function index(req, res) {
       renderProps.params.token = token;
       renderProps.params.referrer = req.headers.referer;
       loadPropsOnServer(renderProps, {}, (err, asyncProps, scriptTag) => {
-        const markup = ReactDom.renderToString(<AsyncProps {...renderProps} {...asyncProps} {...req.query} />);
-        res.render('layouts/react', { markup, scriptTag, csrfToken, bundleName: 'company' });
+        if (err) {
+          res.render('error', {error: err})
+        } else {
+          const markup = ReactDom.renderToString(<AsyncProps {...renderProps} {...asyncProps} {...req.query} />);
+          res.render('layouts/react', { markup, scriptTag, csrfToken, bundleName: 'company' });
+        }
       });
     } else {
       res.status(404).send('Not found');

--- a/src/controllers/contactcontroller.js
+++ b/src/controllers/contactcontroller.js
@@ -38,8 +38,12 @@ function index(req, res) {
     } else if (renderProps) {
       renderProps.params = Object.assign({ token, referrer: req.headers.referer }, renderProps.params, req.query);
       loadPropsOnServer(renderProps, {}, (err, asyncProps, scriptTag) => {
-        const markup = ReactDom.renderToString(<AsyncProps {...renderProps} {...asyncProps} />);
-        res.render('layouts/react', { markup, scriptTag, csrfToken, bundleName: 'contact' });
+        if (err) {
+          res.render('error', {error: err})
+        } else {
+          const markup = ReactDom.renderToString(<AsyncProps {...renderProps} {...asyncProps} />);
+          res.render('layouts/react', { markup, scriptTag, csrfToken, bundleName: 'contact' });
+        }
       });
     } else {
       res.status(404).send('Not found');

--- a/src/repositorys/remotecompanyrepository.js
+++ b/src/repositorys/remotecompanyrepository.js
@@ -1,10 +1,17 @@
-const axios = require('axios');
+const axios = require('axios')
 
-function getCompany(token = null, id, source) {
-  return axios.get(`/api/company/${source}/${id}`)
-    .then(response => response.data);
+function getCompany (token = null, id, source) {
+  return new Promise((resolve, reject) => {
+    axios.get(`/api/company/${source}/${id}`)
+      .then((response) => {
+        resolve(response.data)
+      })
+      .catch((error) => {
+        reject(error)
+      })
+  })
 }
 
 module.exports = {
-  getCompany,
-};
+  getCompany
+}


### PR DESCRIPTION
Added error handler to get initial props. Now when a user tries to load a company or contact that does not exist, or has an error, this is displayed in an error page.