### PR TITLE
Fix compatibility issues with IE10

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/uktrade/data-hub-web"
   },
   "dependencies": {
-    "@uktrade/trade_elements": "^2.6.2",
+    "@uktrade/trade_elements": "^3.0.4",
     "async-props": "^0.3.2",
     "axios": "^0.15.2",
     "babel-cli": "^6.18.0",

--- a/src/components/radio.component.js
+++ b/src/components/radio.component.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const React = require('react')
-const {generateID}= require('@uktrade/trade_elements').elementstuff
+const {generateID} = require('../lib/elementstuff')
 
 class RadioComponent extends React.Component {
 

--- a/src/controls/clipped-list.js
+++ b/src/controls/clipped-list.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const classUtils = require('@uktrade/trade_elements').elementstuff
+const classUtils = require('../lib/elementstuff')
 
 const HIDE = 'hide'
 const SHOW = 'show'

--- a/src/controls/facets.js
+++ b/src/controls/facets.js
@@ -1,8 +1,6 @@
 /* eslint new-cap: 0 */
-
-require('babel-polyfill')
 const getQueryParam = require('../lib/urlstuff').getQueryParam
-const {toggleClass} = require('@uktrade/trade_elements').elementstuff
+const {toggleClass} = require('../lib/elementstuff')
 
 const term = getQueryParam('term')
 
@@ -23,12 +21,13 @@ class Facets {
   addEventHandlers () {
     this.element.addEventListener('click', this.selectOptionHandler, false)
 
-    for (const clearButton of this.clearButtons) {
+    for (let pos = 0; pos < this.clearButtons; pos += 1) {
+      const clearButton = this.clearButtons.item(pos)
       clearButton.addEventListener('click', this.clearFacetSelection)
     }
 
-    for (const collapseButton of this.collapseButtons) {
-      collapseButton.addEventListener('click', this.toggleFacet)
+    for (let pos = 0; pos < this.collapseButtons; pos += 1) {
+      this.collapseButtons.item(pos).addEventListener('click', this.toggleFacet)
     }
   }
 
@@ -36,7 +35,8 @@ class Facets {
     let url = `?term=${term}`
 
     const checkedInputs = this.element.querySelectorAll('input[type=checkbox]:checked')
-    for (const input of checkedInputs) {
+    for (let pos = 0; pos < checkedInputs.length; pos += 1) {
+      const input = checkedInputs.item(pos)
       url += `&${input.name}=${input.value}`
     }
 
@@ -46,7 +46,8 @@ class Facets {
   clearFacetSelection = (event) => {
     const facetWrapper = event.target.parentElement.parentElement.parentElement
     const checkedInputs = facetWrapper.querySelectorAll('input[type=checkbox]:checked')
-    for (const input of checkedInputs) {
+    for (let pos = 0; pos < checkedInputs.length; pos += 1) {
+      const input = checkedInputs.item(pos)
       input.checked = false
     }
     this.selectOptionHandler()

--- a/src/controls/sectors.js
+++ b/src/controls/sectors.js
@@ -1,5 +1,5 @@
 /* eslint no-new: 0 */
-const { createElementFromMarkup, removeElement, hide, insertAfter } = require('@uktrade/trade_elements').elementstuff
+const { createElementFromMarkup, removeElement, hide, insertAfter } = require('../lib/elementstuff')
 const transformSectors = require('../lib/transformsectors')
 
 const PRIMARYPANELMARKUP = `
@@ -52,9 +52,8 @@ class Sectors {
     this.primarySelectElement = this.primaryPanel.querySelector('select')
 
     let primarySelectInnerMarkup = ''
-
-    for (const primarySector of this.primarySectors) {
-      primarySelectInnerMarkup += `<option>${primarySector}</option>`
+    for (let pos = 0; pos < this.primarySectors.length; pos += 1) {
+      primarySelectInnerMarkup += `<option>${this.primarySectors[pos]}</option>`
     }
     this.primarySelectElement.innerHTML = primarySelectInnerMarkup
 
@@ -96,8 +95,8 @@ class Sectors {
   createSubsectorDropdown (subSectors) {
     let markup = '<option value="">Select a sector</option>'
 
-    for (const subSector of subSectors) {
-      markup += `<option value="${subSector.id}">${subSector.name}</option>`
+    for (let pos = 0; pos < subSectors.length; pos += 1) {
+      markup += `<option value="${subSectors[pos].id}">${subSectors[pos].name}</option>`
     }
 
     this.subsectorPanel = createElementFromMarkup(SUBSECTORPANELMARKUP, this.document)

--- a/src/lib/elementstuff.js
+++ b/src/lib/elementstuff.js
@@ -1,0 +1,127 @@
+/* eslint no-useless-escape: 0 */
+const regularExp1 = '(\\s|^)'
+const regularExp2 = '(\\s|$)'
+
+function addClass (element, className) {
+  if (!element) return
+  if (isNodeList(element)) {
+    for (let pos = element.length - 1; pos > -1; pos -= 1) {
+      addClass(element.item(pos), className)
+    }
+  } else if (element.classList) {
+    element.classList.add(className)
+  } else if (!hasClass(element, className)) {
+    element.className += ' ' + className
+  }
+}
+
+function removeClass (element, className) {
+  if (!element) return
+  if (isNodeList(element)) {
+    for (let pos = element.length - 1; pos > -1; pos -= 1) {
+      removeClass(element.item(pos), className)
+    }
+  } else if (element.classList) {
+    element.classList.remove(className)
+  } else if (hasClass(element, className)) {
+    const regClass = new RegExp(regularExp1 + className + regularExp2)
+    element.className = element.className.replace(regClass, ' ')
+  }
+}
+
+function hasClass (element, className) {
+  if (!element) return
+  if (element.classList) {
+    return element.classList.contains(className)
+  }
+  return element.className.match(new RegExp(regularExp1 + className + regularExp2))
+}
+
+function toggleClass (element, className) {
+  if (!element) return
+  if (isNodeList(element)) {
+    for (let pos = element.length - 1; pos > -1; pos -= 1) {
+      toggleClass(element.item(pos), className)
+    }
+  } else if (hasClass(element, className)) {
+    removeClass(element, className)
+  } else {
+    addClass(element, className)
+  }
+}
+
+function generateID () {
+  let d = new Date().getTime()
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (d + Math.random() * 16) % 16 | 0
+    d = Math.floor(d / 16)
+    return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16)
+  })
+}
+
+function isNodeList (nodes) {
+  const stringRepr = Object.prototype.toString.call(nodes)
+
+  return typeof nodes === 'object' &&
+    /^\[object (HTMLCollection|NodeList|Object)\]$/.test(stringRepr) &&
+    (typeof nodes.length === 'number') &&
+    (nodes.length === 0 || (typeof nodes[0] === 'object' && nodes[0].nodeType > 0))
+}
+
+function findDoc (el) {
+  while (el.parentNode) {
+    el = el.parentNode
+  }
+  return el
+}
+
+function insertAfter (newElement, targetElement) {
+  // target is what you want it to go after. Look for this elements parent.
+  const parent = targetElement.parentNode
+
+  // if the parents lastchild is the targetElement...
+  if (parent.lastChild === targetElement) {
+    // add the newElement after the target element.
+    parent.appendChild(newElement)
+  } else {
+    // else the target has siblings, insert the new element between the target and it's next sibling.
+    parent.insertBefore(newElement, targetElement.nextSibling)
+  }
+}
+
+function hide (element) {
+  addClass(element, 'hidden')
+  element.setAttribute('aria-hidden', true)
+}
+
+function show (element) {
+  removeClass(element, 'hidden')
+  element.setAttribute('aria-hidden', false)
+}
+
+function createElementFromMarkup (markup, docToCreateIn) {
+  const documentRef = docToCreateIn || document
+  let tmp = documentRef.createElement('body')
+  tmp.innerHTML = markup
+  return tmp.firstElementChild
+}
+
+function removeElement (element) {
+  if (!element) return
+  element.parentNode.removeChild(element)
+}
+
+module.exports = {
+  addClass,
+  removeClass,
+  hasClass,
+  toggleClass,
+  generateID,
+  isNodeList,
+  findDoc,
+  insertAfter,
+  hide,
+  show,
+  createElementFromMarkup,
+  removeElement
+}

--- a/src/pages/company.js
+++ b/src/pages/company.js
@@ -1,4 +1,3 @@
-require('babel-polyfill')
 const React = require('react')
 const ReactDOM = require('react-dom')
 const Routes = require('./../reactrouting/companyroutes').Routes

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,4 +1,3 @@
-require('babel-polyfill')
 const React = require('react')
 const ReactDOM = require('react-dom')
 const Routes = require('./../reactrouting/contactroutes').Routes

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,4 @@
 /* eslint no-new: 0 */
-require('babel-polyfill')
-
 const ClippedList = require('../controls/clipped-list')
 
 new ClippedList(document.getElementById('interactions-list'), 'See all new interactions', 'See less interactions')

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -1,5 +1,4 @@
 /* eslint no-new: 0 */
-require('babel-polyfill')
 const Facets = require('../controls/facets')
 
 document.addEventListener(

--- a/src/server.js
+++ b/src/server.js
@@ -117,6 +117,7 @@ app.use('/javascripts', express.static(`${__dirname}/../node_modules/@uktrade/tr
 app.use('/fonts', express.static(`${__dirname}/../node_modules/font-awesome/fonts`))
 app.use('/javascripts/react', express.static(`${__dirname}/../node_modules/react/dist`))
 app.use('/javascripts/react-dom', express.static(`${__dirname}/../node_modules/react-dom/dist`))
+app.use('/babel-polyfill', express.static(`${__dirname}/../node_modules/babel-polyfill/dist`))
 
 app.use(logger((isDev ? 'dev' : 'combined')))
 

--- a/src/services/itemcollectionservice.js
+++ b/src/services/itemcollectionservice.js
@@ -19,8 +19,10 @@ function getTimeSinceLastAddedItem (items) {
   if (sorted.length === 0) return null
 
   // Figure out how long sinse now for the latest item
-  const now = new Date().toISOString()
-  const [amount, unit] = DateDiff.timeDiffHuman(sorted[0].created_on, now).split(' ')
+  const now = new Date().toISOString().substring(0, 10)
+  const shortCreated = sorted[0].created_on.substring(0, 10)
+
+  const [amount, unit] = DateDiff.timeDiffHuman(shortCreated, now).split(' ')
   return { amount, unit }
 }
 

--- a/src/views/interaction/add-step-1.html
+++ b/src/views/interaction/add-step-1.html
@@ -50,9 +50,3 @@
     {{ trade.save(backUrl, buttonText="Continue") }}
   </form>
 {% endblock %}
-
-{% block body_end %}
-  <script src="{{ asset_path }}javascripts/radio.bundle.js?{{ startTime }}"></script>
-{% endblock %}
-
-

--- a/src/views/layouts/ukti.html
+++ b/src/views/layouts/ukti.html
@@ -15,6 +15,7 @@
       window.DIT.user = {{ user | stringify | safe }};
     </script>
   {% endif %}
+    <script src="/babel-polyfill/polyfill.min.js"></script>
     <script src="{{ asset_path }}javascripts/common.js?{{ startTime }}"></script>
 {% endblock %}
 


### PR DESCRIPTION
A combination or issues in Trade Elements and prototype meant that some screens would not work with IE10.

A number of things had to be done to fix this:
* Trade elements switch to using babel runtime to polyfill it's code whilst not affecting those projects that depend upon it
* Trade elements stopped using Array.includes in client side code as not supported in <= IE11
* Load babel-polyfill in prototype to fill limitations in IE to allow it to work with webpack, react and axios.
* Moved elementstuff back into prototype as this needs to be transpiled and node modules do not get transpiled. Later this will move back to elements and distribute a transpiled version
* Changed client code to not use for x of y. There seems to be some compatibility issue with babels transpiled code and IE 10 for iteration
* Fixed some loops that used for x of y when they are iterating dom collections, so should use traditional for loop and elements.item(pos)
* Fixed issue when date calculations are carried on dates that span GMT and BST.