### PR TITLE
Rename 'Role' to 'Job title' for contacts

### DIFF
--- a/src/components/contacttable.component.js
+++ b/src/components/contacttable.component.js
@@ -88,7 +88,7 @@ class ContactTable extends React.Component {
             <th
               className={this.columnClass('occupation')}
               onClick={() => { this.changeSort('occupation') }}
-          >Role</th>
+          >Job title</th>
             <th
               className={this.columnClass('telephonenumber')}
               onClick={() => { this.changeSort('telephonenumber') }}

--- a/src/forms/contactform.js
+++ b/src/forms/contactform.js
@@ -16,7 +16,7 @@ const LABELS = {
   'title': 'Title',
   'first_name': 'First name',
   'last_name': 'Last name',
-  'job_title': 'Role',
+  'job_title': 'Job title',
   'telephone_number': 'Phone',
   'email': 'Email address',
   'address': 'Address',

--- a/src/sections/contactdetails.section.js
+++ b/src/sections/contactdetails.section.js
@@ -23,7 +23,7 @@ function contactDetailsSection (props) {
           </tr>
           { contact.job_title &&
             <tr>
-              <th>Role</th>
+              <th>Job title</th>
               <td>{ contact.job_title }</td>
             </tr>
           }


### PR DESCRIPTION
Renames the label for the job_title field in contacts from 'Role' to 'Job title'.