### PR TITLE
Preserve white-space for business description and contact notes

### DIFF
--- a/src/sass/_helpers.scss
+++ b/src/sass/_helpers.scss
@@ -1,0 +1,3 @@
+.preserve-ws {
+  white-space: pre-wrap;
+}

--- a/src/sass/application.scss
+++ b/src/sass/application.scss
@@ -3,6 +3,7 @@ $images-dir: '/images/';
 @import 'trade-elements';
 
 // application specific
+@import 'helpers';
 @import 'dashboard';
 @import 'facets';
 @import 'leads';

--- a/src/sections/companydetails.section.js
+++ b/src/sections/companydetails.section.js
@@ -81,7 +81,7 @@ function companyDetailsSection (props) {
             </tr>
             <tr>
               <th>Business description</th>
-              <td>{ company.description }</td>
+              <td className="preserve-ws">{ company.description }</td>
             </tr>
             <tr>
               <th>Number of employees</th>

--- a/src/sections/contactdetails.section.js
+++ b/src/sections/contactdetails.section.js
@@ -74,7 +74,7 @@ function contactDetailsSection (props) {
           </tr>
           <tr>
             <th>Notes</th>
-            <td>{ contact.notes }</td>
+            <td className="preserve-ws">{ contact.notes }</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
Using `white-space: pre-wrap` via a new CSS class `preserve-ws`.

Interaction notes is unchanged as that table is rendered in a completely different way.